### PR TITLE
Decode keystore to project folder

### DIFF
--- a/action/steps/build.sh
+++ b/action/steps/build.sh
@@ -68,7 +68,7 @@ fi
 if [[ -z $ANDROID_KEYSTORE_NAME || -z $ANDROID_KEYSTORE_BASE64 ]]; then
   echo "Not creating Android keystore."
 else
-  echo "$ANDROID_KEYSTORE_BASE64" | base64 --decode > "$ANDROID_KEYSTORE_NAME"
+  echo "$ANDROID_KEYSTORE_BASE64" | base64 --decode > "$UNITY_PROJECT_PATH/$ANDROID_KEYSTORE_NAME"
   echo "Created Android keystore."
 fi
 


### PR DESCRIPTION
**Changes**

Small change in build script to fix android build signing using androidKeystoreBase64. The problem is observed when the unity project isn't located in the root of the repository. 
Let say you encoded keystore to base64 and it is already in github secrets. Configuration for builder will have these lines:
```
androidKeystoreName: my2.keystore
androidKeystoreBase64: ${{ secrets.ANDROID_KEYSTORE_BASE64}}
```
So during the build base64 will be decoded to `repo/my2.keystore`. 
```
echo "$ANDROID_KEYSTORE_BASE64" | base64 --decode > "$ANDROID_KEYSTORE_NAME"
```
And the value androidKeystoreName will be passed to unity build script
```
if (options.TryGetValue("androidKeystoreName", out string keystoreName) && !string.IsNullOrEmpty(keystoreName))
  PlayerSettings.Android.keystoreName = keystoreName;
```
That means that unity will try to find keystore in folder relative to project. So if your project located for example in `root/my-unity-project/` then unity will expect keystore at `root/my-unity-project/my2.keystore`. But it is not here.

Well my solution is - decode keystore directly to unity folder:
```
echo "$ANDROID_KEYSTORE_BASE64" | base64 --decode > "$UNITY_PROJECT_PATH/$ANDROID_KEYSTORE_NAME"
```

**Checklist**
- [x] Read the contribution guide and accept the code of conduct
- [x] Readme (updated or not needed) - _not needed_
- [x] Tests (added, updated or not needed) - _not needed_