### PR TITLE
Pass buildOptions to the build with customParameters

### DIFF
--- a/action/default-build-script/Assets/Editor/Builder.cs
+++ b/action/default-build-script/Assets/Editor/Builder.cs
@@ -22,7 +22,7 @@ namespace UnityBuilderAction
       // Get all buildOptions from options
       BuildOptions buildOptions = BuildOptions.None;
       foreach (string buildOptionString in Enum.GetNames(typeof(BuildOptions))) {
-        if (providedArguments.ContainsKey(buildOptionString)) {
+        if (options.ContainsKey(buildOptionString)) {
           BuildOptions buildOptionEnum = (BuildOptions) Enum.Parse(typeof(BuildOptions), buildOptionString);
           buildOptions |= buildOptionEnum;
         }

--- a/action/default-build-script/Assets/Editor/Builder.cs
+++ b/action/default-build-script/Assets/Editor/Builder.cs
@@ -18,13 +18,22 @@ namespace UnityBuilderAction
 
       // Gather values from project
       var scenes = EditorBuildSettings.scenes.Where(scene => scene.enabled).Select(s => s.path).ToArray();
+      
+      // Get all buildOptions from options
+      BuildOptions buildOptions = BuildOptions.None;
+      foreach (string buildOptionString in Enum.GetNames(typeof(BuildOptions))) {
+        if (providedArguments.ContainsKey(buildOptionString)) {
+          BuildOptions buildOptionEnum = (BuildOptions) Enum.Parse(typeof(BuildOptions), buildOptionString);
+          buildOptions |= buildOptionEnum;
+        }
+      }
 
       // Define BuildPlayer Options
-      var buildOptions = new BuildPlayerOptions {
+      var buildPlayerOptions = new BuildPlayerOptions {
         scenes = scenes,
         locationPathName = options["customBuildPath"],
         target = (BuildTarget) Enum.Parse(typeof(BuildTarget), options["buildTarget"]),
-        options = BuildOptions.EnableHeadlessMode
+        options = buildOptions
       };
 
       // Set version for this build
@@ -32,11 +41,11 @@ namespace UnityBuilderAction
       VersionApplicator.SetAndroidVersionCode(options["androidVersionCode"]);
       
       // Apply Android settings
-      if (buildOptions.target == BuildTarget.Android)
+      if (buildPlayerOptions.target == BuildTarget.Android)
         AndroidSettings.Apply(options);
 
       // Perform build
-      BuildReport buildReport = BuildPipeline.BuildPlayer(buildOptions);
+      BuildReport buildReport = BuildPipeline.BuildPlayer(buildPlayerOptions);
 
       // Summary
       BuildSummary summary = buildReport.summary;

--- a/action/default-build-script/Assets/Editor/Builder.cs
+++ b/action/default-build-script/Assets/Editor/Builder.cs
@@ -24,6 +24,7 @@ namespace UnityBuilderAction
         scenes = scenes,
         locationPathName = options["customBuildPath"],
         target = (BuildTarget) Enum.Parse(typeof(BuildTarget), options["buildTarget"]),
+        options = BuildOptions.EnableHeadlessMode
       };
 
       // Set version for this build


### PR DESCRIPTION
#### Changes

- In unity there is an options to add https://docs.unity3d.com/ScriptReference/BuildOptions.html into build. This change allow user to add customParameters as normal (-EnableHeadlessMode) and if any of these are in that Enum they will be taken into account for the build.

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)
