### PR TITLE
Set locale to C.UTF-8 in Dockerfile

### DIFF
--- a/action/Dockerfile
+++ b/action/Dockerfile
@@ -10,6 +10,10 @@ LABEL "repository"="http://github.com/webbertakken/unity-actions"
 LABEL "homepage"="http://github.com/webbertakken/unity-actions"
 LABEL "maintainer"="Webber Takken <webber@takken.io>"
 
+# To be moved to base image
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
+
 ADD default-build-script /UnityBuilderAction
 ADD steps /steps
 RUN chmod -R +x /steps


### PR DESCRIPTION
#### Changes

- Sets the locale to C.UTF-8 in Dockerfile
- This fixes a Gradle crash while building for Android on Unity 2019 when there are accented characters in the environment variables

#### Checklist

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme not needed
- [x] Tests not needed (I think?)
