### PR TITLE
Remove debug from versioning

### DIFF
--- a/src/model/versioning.js
+++ b/src/model/versioning.js
@@ -228,7 +228,7 @@ export default class Versioning {
    * identifies the current commit.
    */
   static async getVersionDescription() {
-    return this.git(['describe', '--long', '--tags', '--always', '--debug', this.sha]);
+    return this.git(['describe', '--long', '--tags', '--always', this.sha]);
   }
 
   /**


### PR DESCRIPTION
Would like to remove this debug option, as I don't like how it generates many unnecessary warnings, and I don't think it provides any value.

#### Changes

- Remove these:
![image](https://user-images.githubusercontent.com/1088474/105884378-8b9a1f00-5fcd-11eb-81ef-5564cab8fbeb.png)


#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [ ] Readme (updated or not needed)
- [ ] Tests (added, updated or not needed)
