### PR TITLE
Pass on USYM_UPLOAD_AUTH_TOKEN if defined

### DIFF
--- a/src/model/docker.ts
+++ b/src/model/docker.ts
@@ -47,6 +47,7 @@ class Docker {
         --env UNITY_PASSWORD \
         --env UNITY_SERIAL \
         --env UNITY_VERSION="${version}" \
+        --env USYM_UPLOAD_AUTH_TOKEN \
         --env PROJECT_PATH="${projectPath}" \
         --env BUILD_TARGET="${platform}" \
         --env BUILD_NAME="${buildName}" \


### PR DESCRIPTION
To automatically upload symbols to unity, we need to define the `USYM_UPLOAD_AUTH_TOKEN` variable. Currently the build container ignores this variable, even if it's defined in the github action.

```
2021-03-26T02:35:35.5938747Z time="2021-03-26T02:35:35Z" level=fatal msg="Please provide an auth token with USYM_UPLOAD_AUTH_TOKEN environment variable"
```

#### Changes

- Passes on `USYM_UPLOAD_AUTH_TOKEN` to the docker process, if it's defined

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (not needed)
- [x] Tests (not needed)
