### PR TITLE
Fix build script for Unity 2018, by using reflection instead of version defines

### DIFF
--- a/dist/default-build-script/Assets/Editor/UnityBuilderAction/UnityBuilderAction.asmdef
+++ b/dist/default-build-script/Assets/Editor/UnityBuilderAction/UnityBuilderAction.asmdef
@@ -1,8 +1,6 @@
 {
     "name": "UnityBuilderAction",
-    "references": [
-        "Unity.Addressables.Editor"
-    ],
+    "references": [],
     "includePlatforms": [
         "Editor"
     ],
@@ -12,12 +10,6 @@
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],
-    "versionDefines": [
-        {
-            "name": "com.unity.addressables",
-            "expression": "1.0.0",
-            "define": "USE_ADDRESSABLES"
-        }
-    ],
+    "versionDefines": [],
     "noEngineReferences": false
 }


### PR DESCRIPTION
#### Changes

- Use reflection instead of version defines to see if the addressables package is installed.

Fixes #233

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [ ] Tests (added, updated or not needed)
