### PR TITLE
Using SSH_AUTH_SOCK (ssh agent forwarding) to pull upm private repos

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -106,6 +106,10 @@ inputs:
 
       Parameters must start with a hyphen (-) and may be followed by a value (without hyphen).
       Parameters without a value will be considered booleans (with a value of true).
+  sshAgent:
+    required: false
+    default: ''
+    description: 'SSH Agent path to forward to the container'
   chownFilesTo:
     required: false
     default: ''

--- a/dist/Dockerfile
+++ b/dist/Dockerfile
@@ -17,4 +17,6 @@ ADD entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 RUN ls
 
+RUN apt-get update && apt-get install -y openssh-client
+
 ENTRYPOINT ["/entrypoint.sh"]

--- a/dist/Dockerfile
+++ b/dist/Dockerfile
@@ -17,6 +17,4 @@ ADD entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 RUN ls
 
-RUN apt-get update && apt-get install -y openssh-client
-
 ENTRYPOINT ["/entrypoint.sh"]

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ async function run() {
     Action.checkCompatibility();
     Cache.verify();
 
-    const { dockerfile, workspace, actionFolder } = Action;
+    const { dockerfile, workspace, actionFolder, sshAgent } = Action;
 
     const buildParameters = await BuildParameters.create();
     const baseImage = new ImageTag(buildParameters);
@@ -27,7 +27,7 @@ async function run() {
       default:
         core.info('Building locally');
         builtImage = await Docker.build({ path: actionFolder, dockerfile, baseImage });
-        await Docker.run(builtImage, { workspace, ...buildParameters });
+        await Docker.run(builtImage, { workspace, sshAgent, ...buildParameters });
         break;
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ async function run() {
     Action.checkCompatibility();
     Cache.verify();
 
-    const { dockerfile, workspace, actionFolder, sshAgent } = Action;
+    const { dockerfile, workspace, actionFolder } = Action;
 
     const buildParameters = await BuildParameters.create();
     const baseImage = new ImageTag(buildParameters);
@@ -27,7 +27,7 @@ async function run() {
       default:
         core.info('Building locally');
         builtImage = await Docker.build({ path: actionFolder, dockerfile, baseImage });
-        await Docker.run(builtImage, { workspace, sshAgent, ...buildParameters });
+        await Docker.run(builtImage, { workspace, ...buildParameters });
         break;
     }
 

--- a/src/model/__mocks__/input.ts
+++ b/src/model/__mocks__/input.ts
@@ -10,6 +10,7 @@ export const mockGetFromUser = jest.fn().mockResolvedValue({
   buildMethod: undefined,
   buildVersion: '1.3.37',
   customParameters: '',
+  sshAgent: '',
   chownFilesTo: '',
 });
 

--- a/src/model/action.ts
+++ b/src/model/action.ts
@@ -37,10 +37,6 @@ class Action {
     return process.env.GITHUB_WORKSPACE;
   }
 
-  static get sshAgent() {
-    return process.env.SSH_AUTH_SOCK;
-  }
-
   static checkCompatibility() {
     const currentPlatform = process.platform;
     if (!Action.supportedPlatforms.includes(currentPlatform)) {

--- a/src/model/action.ts
+++ b/src/model/action.ts
@@ -37,6 +37,10 @@ class Action {
     return process.env.GITHUB_WORKSPACE;
   }
 
+  static get sshAgent() {
+    return process.env.SSH_AUTH_SOCK;
+  }
+
   static checkCompatibility() {
     const currentPlatform = process.platform;
     if (!Action.supportedPlatforms.includes(currentPlatform)) {

--- a/src/model/build-parameters.ts
+++ b/src/model/build-parameters.ts
@@ -60,6 +60,7 @@ class BuildParameters {
       androidKeyaliasName: Input.androidKeyaliasName,
       androidKeyaliasPass: Input.androidKeyaliasPass,
       customParameters: Input.customParameters,
+      sshAgent: Input.sshAgent,
       chownFilesTo: Input.chownFilesTo,
       remoteBuildCluster: Input.remoteBuildCluster,
       awsStackName: Input.awsStackName,

--- a/src/model/build-parameters.ts
+++ b/src/model/build-parameters.ts
@@ -22,6 +22,7 @@ class BuildParameters {
   public androidKeyaliasName!: string;
   public androidKeyaliasPass!: string;
   public customParameters!: string;
+  public sshAgent!: string;
   public remoteBuildCluster!: string;
   public awsStackName!: string;
   public kubeConfig!: string;

--- a/src/model/docker.ts
+++ b/src/model/docker.ts
@@ -85,7 +85,7 @@ class Docker {
         --volume "${runnerTempPath}/_github_home":"/root" \
         --volume "${runnerTempPath}/_github_workflow":"/github/workflow" \
         --volume "${workspace}":"/github/workspace" \
-        ${sshAgent ? '--volume ' + sshAgent + ':/ssh-agent' : ''} \
+        ${sshAgent ? `--volume ${sshAgent}:/ssh-agent` : ''} \
         ${sshAgent ? '--volume /home/runner/.ssh/known_hosts:/root/.ssh/known_hosts:ro' : ''} \
         ${image}`;
 

--- a/src/model/docker.ts
+++ b/src/model/docker.ts
@@ -37,6 +37,7 @@ class Docker {
       androidKeyaliasPass,
       customParameters,
       chownFilesTo,
+      sshAgent,
     } = parameters;
 
     const command = `docker run \
@@ -79,10 +80,13 @@ class Docker {
         --env RUNNER_TOOL_CACHE \
         --env RUNNER_TEMP \
         --env RUNNER_WORKSPACE \
+        --env SSH_AUTH_SOCK=/ssh-agent \
         --volume "/var/run/docker.sock":"/var/run/docker.sock" \
         --volume "${runnerTempPath}/_github_home":"/root" \
         --volume "${runnerTempPath}/_github_workflow":"/github/workflow" \
         --volume "${workspace}":"/github/workspace" \
+        --volume "${sshAgent}":"/ssh-agent" \
+        --volume /home/runner/.ssh/known_hosts:/root/.ssh/known_hosts:ro \
         ${image}`;
 
     await exec(command, undefined, { silent });

--- a/src/model/docker.ts
+++ b/src/model/docker.ts
@@ -36,8 +36,8 @@ class Docker {
       androidKeyaliasName,
       androidKeyaliasPass,
       customParameters,
-      chownFilesTo,
       sshAgent,
+      chownFilesTo,
     } = parameters;
 
     const command = `docker run \
@@ -80,13 +80,13 @@ class Docker {
         --env RUNNER_TOOL_CACHE \
         --env RUNNER_TEMP \
         --env RUNNER_WORKSPACE \
-        --env SSH_AUTH_SOCK=/ssh-agent \
+        ${sshAgent ? '--env SSH_AUTH_SOCK=/ssh-agent' : ''} \
         --volume "/var/run/docker.sock":"/var/run/docker.sock" \
         --volume "${runnerTempPath}/_github_home":"/root" \
         --volume "${runnerTempPath}/_github_workflow":"/github/workflow" \
         --volume "${workspace}":"/github/workspace" \
-        --volume "${sshAgent}":"/ssh-agent" \
-        --volume /home/runner/.ssh/known_hosts:/root/.ssh/known_hosts:ro \
+        ${sshAgent ? "--volume " + sshAgent + ":/ssh-agent" : ''} \
+        ${sshAgent ? '--volume /home/runner/.ssh/known_hosts:/root/.ssh/known_hosts:ro' : ''} \
         ${image}`;
 
     await exec(command, undefined, { silent });

--- a/src/model/docker.ts
+++ b/src/model/docker.ts
@@ -85,7 +85,7 @@ class Docker {
         --volume "${runnerTempPath}/_github_home":"/root" \
         --volume "${runnerTempPath}/_github_workflow":"/github/workflow" \
         --volume "${workspace}":"/github/workspace" \
-        ${sshAgent ? "--volume " + sshAgent + ":/ssh-agent" : ''} \
+        ${sshAgent ? '--volume ' + sshAgent + ':/ssh-agent' : ''} \
         ${sshAgent ? '--volume /home/runner/.ssh/known_hosts:/root/.ssh/known_hosts:ro' : ''} \
         ${image}`;
 

--- a/src/model/input.ts
+++ b/src/model/input.ts
@@ -85,6 +85,10 @@ class Input {
     return core.getInput('customParameters') || '';
   }
 
+  static get sshAgent() {
+    return core.getInput('sshAgent') || '';
+  }
+
   static get chownFilesTo() {
     return core.getInput('chownFilesTo') || '';
   }


### PR DESCRIPTION
#### Changes

- This PR is a proposal to fix this issue: https://github.com/game-ci/unity-builder/issues/161
- In order to get the SSH_AUTH_SOCK we used https://github.com/webfactory/ssh-agent/issues/11
- sshAgent is an optional input parameter.

## Usage
```

      - name: Setup SSH Agent
        uses: webfactory/ssh-agent@v0.5.2
        with:
          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}

      - name: Unity Builder
        uses: ivan-hernandez-scopely/unity-builder@feature/ssh-agent-for-private-upm
        env:
          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
          UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
        with:
          projectPath: ${{ matrix.projectPath }}
          targetPlatform: ${{ matrix.targetPlatform }}
          sshAgent: ${{ env.SSH_AUTH_SOCK }}
```

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)
