### PR TITLE
Remove -nographics flag, ensure single -batchmode flag

### DIFF
--- a/dist/Dockerfile
+++ b/dist/Dockerfile
@@ -17,13 +17,4 @@ ADD entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 RUN ls
 
-# Set frontend to Noninteractive
-# https://github.com/phusion/baseimage-docker/issues/58#issuecomment-47995343
-RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
-
-RUN apt-get -q update \
- && apt-get -q install -y --no-install-recommends --allow-downgrades \
- libnotify4 \
- && apt-get clean
-
 ENTRYPOINT ["/entrypoint.sh"]

--- a/dist/Dockerfile
+++ b/dist/Dockerfile
@@ -17,10 +17,13 @@ ADD entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 RUN ls
 
+# Set frontend to Noninteractive
+# https://github.com/phusion/baseimage-docker/issues/58#issuecomment-47995343
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+
 RUN apt-get -q update \
  && apt-get -q install -y --no-install-recommends --allow-downgrades \
  libnotify4 \
- libnotify-bin \
  && apt-get clean
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/dist/Dockerfile
+++ b/dist/Dockerfile
@@ -17,4 +17,10 @@ ADD entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 RUN ls
 
+RUN apt-get -q update \
+ && apt-get -q install -y --no-install-recommends --allow-downgrades \
+ libnotify4 \
+ libnotify-bin \
+ && apt-get clean
+
 ENTRYPOINT ["/entrypoint.sh"]

--- a/dist/steps/activate.sh
+++ b/dist/steps/activate.sh
@@ -25,7 +25,7 @@ if [[ -n "$UNITY_LICENSE" ]] || [[ -n "$UNITY_LICENSE_FILE" ]]; then
 
   # Activate license
   ACTIVATION_OUTPUT=$(unity-editor \
-      -nographics \
+      -batchmode \
       -logFile /dev/stdout \
       -quit \
       -manualLicenseFile $FILE_PATH)
@@ -63,7 +63,6 @@ elif [[ -n "$UNITY_SERIAL" && -n "$UNITY_EMAIL" && -n "$UNITY_PASSWORD" ]]; then
   # Activate license
   unity-editor \
     -batchmode \
-    -nographics \
     -logFile /dev/stdout \
     -quit \
     -serial "$UNITY_SERIAL" \

--- a/dist/steps/activate.sh
+++ b/dist/steps/activate.sh
@@ -25,7 +25,6 @@ if [[ -n "$UNITY_LICENSE" ]] || [[ -n "$UNITY_LICENSE_FILE" ]]; then
 
   # Activate license
   ACTIVATION_OUTPUT=$(unity-editor \
-      -batchmode \
       -logFile /dev/stdout \
       -quit \
       -manualLicenseFile $FILE_PATH)
@@ -62,7 +61,6 @@ elif [[ -n "$UNITY_SERIAL" && -n "$UNITY_EMAIL" && -n "$UNITY_PASSWORD" ]]; then
 
   # Activate license
   unity-editor \
-    -batchmode \
     -logFile /dev/stdout \
     -quit \
     -serial "$UNITY_SERIAL" \

--- a/dist/steps/build.sh
+++ b/dist/steps/build.sh
@@ -116,7 +116,6 @@ echo ""
 # Reference: https://docs.unity3d.com/2019.3/Documentation/Manual/CommandLineArguments.html
 
 unity-editor \
-  -batchmode \
   -logfile /dev/stdout \
   -quit \
   -customBuildName "$BUILD_NAME" \

--- a/dist/steps/build.sh
+++ b/dist/steps/build.sh
@@ -116,7 +116,7 @@ echo ""
 # Reference: https://docs.unity3d.com/2019.3/Documentation/Manual/CommandLineArguments.html
 
 unity-editor \
-  -nographics \
+  -batchmode \
   -logfile /dev/stdout \
   -quit \
   -customBuildName "$BUILD_NAME" \

--- a/dist/steps/return_license.sh
+++ b/dist/steps/return_license.sh
@@ -7,7 +7,6 @@ if [[ -n "$UNITY_SERIAL" ]]; then
   # This will return the license that is currently in use.
   #
   unity-editor \
-    -batchmode \
     -logFile /dev/stdout \
     -quit \
     -returnlicense

--- a/dist/steps/return_license.sh
+++ b/dist/steps/return_license.sh
@@ -7,7 +7,7 @@ if [[ -n "$UNITY_SERIAL" ]]; then
   # This will return the license that is currently in use.
   #
   unity-editor \
-    -nographics \
+    -batchmode \
     -logFile /dev/stdout \
     -quit \
     -returnlicense


### PR DESCRIPTION
#### Changes

- Remove -nographics flag
- Ensure -batchmode flag is set (only once) (currently is set in the docker [alias `unity-editor`](https://github.com/game-ci/docker/blob/5269da7520bdb336606ff8bbc44dc6983f7a1889/editor/Dockerfile#L39)) 

#### Other considerations

- Install libnotify (to be moved to the docker repo).
- Set debian frontend to default `Noninteractive`.
- I tried the solutions from https://unix.stackexchange.com/questions/2881/show-a-notification-across-all-running-x-displays, specifically the ones that seemed to make it possible to output events in tty console. However this doesn't seem to work in `Noninteractive` mode. 
- Many options require xserver to even listen to dbus.

#### Related issues

- Relies on: https://github.com/game-ci/docker/pull/115

(which means the fix will only fully work after docker images v0.13 release)

- Fixes https://github.com/game-ci/unity-actions/issues/101
- Fixes https://github.com/game-ci/unity-actions/issues/84
- Fixes https://github.com/game-ci/unity-test-runner/issues/68

#### Tests

Tests were performed in https://github.com/game-ci/unity-actions/pull/105

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [ ] Readme (updated or not needed)
- [ ] Tests (added, updated or not needed)
