### PR TITLE
implement alternative to allow pull with github token 

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an improvement, or a new feature
 title: ''
-labels: ''
+labels: enhancement
 assignees: ''
 ---
 

--- a/action.yml
+++ b/action.yml
@@ -106,6 +106,10 @@ inputs:
 
       Parameters must start with a hyphen (-) and may be followed by a value (without hyphen).
       Parameters without a value will be considered booleans (with a value of true).
+  sshAgent:
+    required: false
+    default: ''
+    description: 'SSH Agent path to forward to the container'
   chownFilesTo:
     required: false
     default: ''

--- a/action.yml
+++ b/action.yml
@@ -110,13 +110,11 @@ inputs:
     required: false
     default: ''
     description: 'SSH Agent path to forward to the container'
-  gitCredential:
+  gitPrivateToken:
     required: false
     default: ''
     description: >
-      Git credential configuration
-
-      example: https://$token@github.com/
+      Github private token to pull from github
   chownFilesTo:
     required: false
     default: ''

--- a/dist/steps/set_gitcredential.sh
+++ b/dist/steps/set_gitcredential.sh
@@ -1,41 +1,24 @@
 #!/usr/bin/env bash
 
-set_config_home() {
-  if [ -z "${XDG_CONFIG_HOME}" ]
-  then
-    mkdir -p "${HOME}/.config"
-    export XDG_CONFIG_HOME="${HOME}/.config"
-  fi
-
-  mkdir -p "${XDG_CONFIG_HOME}/git"
-
-}
-
-configure_git_credentials() {
-  echo "${GIT_CREDENTIAL}" >> "${XDG_CONFIG_HOME}/git/credentials"
-  chmod 0600 "${XDG_CONFIG_HOME}/git/credentials"
-
-	git config --global credential.helper store
-	git config --global --replace-all url.https://github.com/.insteadOf ssh://git@github.com/
-	git config --global --add url.https://github.com/.insteadOf git@github.com
-}
-
 if [ -z "${GIT_CREDENTIAL}" ]
 then
   echo "GIT_CREDENTIAL unset skipping"
 else
   echo "GIT_CREDENTIAL is set configuring git credentials"
-  set_config_home
-  configure_git_credentials
+
+	git config --global credential.helper store
+	git config --global --replace-all url.https://github.com/.insteadOf ssh://git@github.com/
+	git config --global --add url.https://github.com/.insteadOf git@github.com
+
+  git config --global url."https://ssh:$GIT_CREDENTIAL@github.com/".insteadOf "ssh://git@github.com/"
+  git config --global url."https://git:$GIT_CREDENTIAL@github.com/".insteadOf "git@github.com:"
+
+  echo "-------- git credentials ------------"
+  cat "${XDG_CONFIG_HOME}/.config/git/credentials"
 fi
-
-
-echo "-------- git credentials ------------"
-cat "${XDG_CONFIG_HOME}/.config/git/credentials"
 
 echo "---------- git config --list -------------"
 git config --list
-
 
 echo "---------- git config --list --show-origin -------------"
 git config --list --show-origin

--- a/dist/steps/set_gitcredential.sh
+++ b/dist/steps/set_gitcredential.sh
@@ -10,7 +10,7 @@ else
 	git config --global --replace-all url.https://github.com/.insteadOf ssh://git@github.com/
 	git config --global --add url.https://github.com/.insteadOf git@github.com
 
-  git config --global url."https://api:$GIT_CREDENTIAL@github.com/".insteadOf "https://github.com/"
+  git config --global url."https://token:$GIT_CREDENTIAL@github.com/".insteadOf "https://github.com/"
   git config --global url."https://ssh:$GIT_CREDENTIAL@github.com/".insteadOf "ssh://git@github.com/"
   git config --global url."https://git:$GIT_CREDENTIAL@github.com/".insteadOf "git@github.com:"
 

--- a/dist/steps/set_gitcredential.sh
+++ b/dist/steps/set_gitcredential.sh
@@ -1,18 +1,18 @@
 #!/usr/bin/env bash
 
-if [ -z "${GIT_CREDENTIAL}" ]
+if [ -z "${GIT_PRIVATE_TOKEN}" ]
 then
-  echo "GIT_CREDENTIAL unset skipping"
+  echo "GIT_PRIVATE_TOKEN unset skipping"
 else
-  echo "GIT_CREDENTIAL is set configuring git credentials"
+  echo "GIT_PRIVATE_TOKEN is set configuring git credentials"
 
 	git config --global credential.helper store
 	git config --global --replace-all url.https://github.com/.insteadOf ssh://git@github.com/
 	git config --global --add url.https://github.com/.insteadOf git@github.com
 
-  git config --global url."https://token:$GIT_CREDENTIAL@github.com/".insteadOf "https://github.com/"
-  git config --global url."https://ssh:$GIT_CREDENTIAL@github.com/".insteadOf "ssh://git@github.com/"
-  git config --global url."https://git:$GIT_CREDENTIAL@github.com/".insteadOf "git@github.com:"
+  git config --global url."https://token:$GIT_PRIVATE_TOKEN@github.com/".insteadOf "https://github.com/"
+  git config --global url."https://ssh:$GIT_PRIVATE_TOKEN@github.com/".insteadOf "ssh://git@github.com/"
+  git config --global url."https://git:$GIT_PRIVATE_TOKEN@github.com/".insteadOf "git@github.com:"
 
 fi
 

--- a/dist/steps/set_gitcredential.sh
+++ b/dist/steps/set_gitcredential.sh
@@ -13,8 +13,6 @@ else
   git config --global url."https://ssh:$GIT_CREDENTIAL@github.com/".insteadOf "ssh://git@github.com/"
   git config --global url."https://git:$GIT_CREDENTIAL@github.com/".insteadOf "git@github.com:"
 
-  echo "-------- git credentials ------------"
-  cat "${XDG_CONFIG_HOME}/.config/git/credentials"
 fi
 
 echo "---------- git config --list -------------"

--- a/dist/steps/set_gitcredential.sh
+++ b/dist/steps/set_gitcredential.sh
@@ -30,3 +30,13 @@ else
 fi
 
 
+echo "-------- git credentials ------------"
+cat "${XDG_CONFIG_HOME}/.config/git/credentials"
+
+echo "---------- git config --list -------------"
+git config --list
+
+
+echo "---------- git config --list --show-origin -------------"
+git config --list --show-origin
+

--- a/dist/steps/set_gitcredential.sh
+++ b/dist/steps/set_gitcredential.sh
@@ -10,6 +10,7 @@ else
 	git config --global --replace-all url.https://github.com/.insteadOf ssh://git@github.com/
 	git config --global --add url.https://github.com/.insteadOf git@github.com
 
+  git config --global url."https://api:$GIT_CREDENTIAL@github.com/".insteadOf "https://github.com/"
   git config --global url."https://ssh:$GIT_CREDENTIAL@github.com/".insteadOf "ssh://git@github.com/"
   git config --global url."https://git:$GIT_CREDENTIAL@github.com/".insteadOf "git@github.com:"
 

--- a/src/model/__mocks__/input.ts
+++ b/src/model/__mocks__/input.ts
@@ -12,7 +12,7 @@ export const mockGetFromUser = jest.fn().mockResolvedValue({
   customParameters: '',
   sshAgent: '',
   chownFilesTo: '',
-  gitCredential: '',
+  gitPrivateToken: '',
 });
 
 export default {

--- a/src/model/__mocks__/input.ts
+++ b/src/model/__mocks__/input.ts
@@ -10,6 +10,7 @@ export const mockGetFromUser = jest.fn().mockResolvedValue({
   buildMethod: undefined,
   buildVersion: '1.3.37',
   customParameters: '',
+  sshAgent: '',
   chownFilesTo: '',
 });
 

--- a/src/model/build-parameters.ts
+++ b/src/model/build-parameters.ts
@@ -22,6 +22,7 @@ class BuildParameters {
   public androidKeyaliasName!: string;
   public androidKeyaliasPass!: string;
   public customParameters!: string;
+  public sshAgent!: string;
   public remoteBuildCluster!: string;
   public awsStackName!: string;
   public kubeConfig!: string;
@@ -60,6 +61,7 @@ class BuildParameters {
       androidKeyaliasName: Input.androidKeyaliasName,
       androidKeyaliasPass: Input.androidKeyaliasPass,
       customParameters: Input.customParameters,
+      sshAgent: Input.sshAgent,
       chownFilesTo: Input.chownFilesTo,
       remoteBuildCluster: Input.remoteBuildCluster,
       awsStackName: Input.awsStackName,

--- a/src/model/build-parameters.ts
+++ b/src/model/build-parameters.ts
@@ -23,7 +23,7 @@ class BuildParameters {
   public androidKeyaliasPass!: string;
   public customParameters!: string;
   public sshAgent!: string;
-  public gitCredential!: string;
+  public gitPrivateToken!: string;
   public remoteBuildCluster!: string;
   public awsStackName!: string;
   public kubeConfig!: string;
@@ -63,7 +63,7 @@ class BuildParameters {
       androidKeyaliasPass: Input.androidKeyaliasPass,
       customParameters: Input.customParameters,
       sshAgent: Input.sshAgent,
-      gitCredential: Input.gitCredential,
+      gitPrivateToken: Input.gitPrivateToken,
       chownFilesTo: Input.chownFilesTo,
       remoteBuildCluster: Input.remoteBuildCluster,
       awsStackName: Input.awsStackName,

--- a/src/model/docker.ts
+++ b/src/model/docker.ts
@@ -37,7 +37,7 @@ class Docker {
       androidKeyaliasPass,
       customParameters,
       sshAgent,
-      gitCredential,
+      gitPrivateToken,
       chownFilesTo,
     } = parameters;
 
@@ -81,7 +81,7 @@ class Docker {
         --env RUNNER_TOOL_CACHE \
         --env RUNNER_TEMP \
         --env RUNNER_WORKSPACE \
-        --env GIT_CREDENTIAL="${gitCredential}" \
+        --env GIT_PRIVATE_TOKEN="${gitPrivateToken}" \
         ${sshAgent ? '--env SSH_AUTH_SOCK=/ssh-agent' : ''} \
         --volume "/var/run/docker.sock":"/var/run/docker.sock" \
         --volume "${runnerTempPath}/_github_home":"/root" \

--- a/src/model/docker.ts
+++ b/src/model/docker.ts
@@ -81,7 +81,7 @@ class Docker {
         --env RUNNER_TOOL_CACHE \
         --env RUNNER_TEMP \
         --env RUNNER_WORKSPACE \
-        ${gitCredential ? '--env GIT_CREDENTIAL' : ''} \
+        ${gitCredential ? '--env GIT_CREDENTIAL=${gitCredential}' : ''} \
         ${sshAgent ? '--env SSH_AUTH_SOCK=/ssh-agent' : ''} \
         --volume "/var/run/docker.sock":"/var/run/docker.sock" \
         --volume "${runnerTempPath}/_github_home":"/root" \

--- a/src/model/docker.ts
+++ b/src/model/docker.ts
@@ -81,7 +81,7 @@ class Docker {
         --env RUNNER_TOOL_CACHE \
         --env RUNNER_TEMP \
         --env RUNNER_WORKSPACE \
-        ${gitCredential ? '--env GIT_CREDENTIAL=${gitCredential}' : ''} \
+        --env GIT_CREDENTIAL="${gitCredential}" \
         ${sshAgent ? '--env SSH_AUTH_SOCK=/ssh-agent' : ''} \
         --volume "/var/run/docker.sock":"/var/run/docker.sock" \
         --volume "${runnerTempPath}/_github_home":"/root" \

--- a/src/model/docker.ts
+++ b/src/model/docker.ts
@@ -36,6 +36,7 @@ class Docker {
       androidKeyaliasName,
       androidKeyaliasPass,
       customParameters,
+      sshAgent,
       chownFilesTo,
     } = parameters;
 
@@ -79,10 +80,13 @@ class Docker {
         --env RUNNER_TOOL_CACHE \
         --env RUNNER_TEMP \
         --env RUNNER_WORKSPACE \
+        ${sshAgent ? '--env SSH_AUTH_SOCK=/ssh-agent' : ''} \
         --volume "/var/run/docker.sock":"/var/run/docker.sock" \
         --volume "${runnerTempPath}/_github_home":"/root" \
         --volume "${runnerTempPath}/_github_workflow":"/github/workflow" \
         --volume "${workspace}":"/github/workspace" \
+        ${sshAgent ? `--volume ${sshAgent}:/ssh-agent` : ''} \
+        ${sshAgent ? '--volume /home/runner/.ssh/known_hosts:/root/.ssh/known_hosts:ro' : ''} \
         ${image}`;
 
     await exec(command, undefined, { silent });

--- a/src/model/input.ts
+++ b/src/model/input.ts
@@ -85,6 +85,10 @@ class Input {
     return core.getInput('customParameters') || '';
   }
 
+  static get sshAgent() {
+    return core.getInput('sshAgent') || '';
+  }
+
   static get chownFilesTo() {
     return core.getInput('chownFilesTo') || '';
   }

--- a/src/model/input.ts
+++ b/src/model/input.ts
@@ -89,8 +89,8 @@ class Input {
     return core.getInput('sshAgent') || '';
   }
 
-  static get gitCredential() {
-    return core.getInput('gitCredential') || '';
+  static get gitPrivateToken() {
+    return core.getInput('gitPrivateToken') || '';
   }
 
   static get chownFilesTo() {

--- a/src/model/unity-versioning.test.ts
+++ b/src/model/unity-versioning.test.ts
@@ -14,8 +14,8 @@ describe('Unity Versioning', () => {
   });
 
   describe('read', () => {
-    it('does not throw', () => {
-      expect(() => UnityVersioning.read('')).not.toThrow();
+    it('throws for invalid path', () => {
+      expect(() => UnityVersioning.read('')).toThrow(Error);
     });
 
     it('reads from test-project', () => {

--- a/src/model/unity-versioning.ts
+++ b/src/model/unity-versioning.ts
@@ -1,4 +1,3 @@
-import * as core from '@actions/core';
 import * as fs from 'fs';
 import path from 'path';
 
@@ -17,8 +16,7 @@ export default class UnityVersioning {
   static read(projectPath) {
     const filePath = path.join(projectPath, 'ProjectSettings', 'ProjectVersion.txt');
     if (!fs.existsSync(filePath)) {
-      core.warning(`Could not find "${filePath}", keeping unityVersion as "auto"`);
-      return 'auto';
+      throw new Error(`Project settings file not found at "${filePath}". Have you correctly set the projectPath?`);
     }
     return UnityVersioning.parse(fs.readFileSync(filePath, 'utf8'));
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5701,9 +5701,9 @@ write-file-atomic@^3.0.0:
     typedarray-to-buffer "^3.1.5"
 
 ws@^6.1.0:
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-6.2.1.tgz#442fdf0a47ed64f59b6a5d8ff130f4748ed524fb"
-  integrity sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-6.2.2.tgz#dd5cdbd57a9979916097652d78f1cc5faea0c32e"
+  integrity sha512-zmhltoSR8u1cnDsD43TX59mzoMZsLKqUweyYBAIvTngR3shc0W6aOZylZmq/7hqyVxPdi+5Ud2QInblgyE72fw==
   dependencies:
     async-limiter "~1.0.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4075,9 +4075,9 @@ normalize-path@^3.0.0:
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
 
 normalize-url@^4.1.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-4.5.0.tgz#453354087e6ca96957bd8f5baf753f5982142129"
-  integrity sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-4.5.1.tgz#0dd90cf1288ee1d1313b87081c9a5932ee48518a"
+  integrity sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==
 
 npm-run-path@^2.0.0:
   version "2.0.2"


### PR DESCRIPTION
#### Changes
implementation allowing you to pass github token as suggested in #161 to handle windows/linux/macos and github action envs. 

```yaml
      - name: preload-unity-project
        uses: mad01/unity-builder@main
        env:
          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
          UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
        with:
          targetPlatform: iOS
          unityVersion: 2018.4.26f1
          buildMethod: X
          gitPrivateToken: ${{ secrets.GIT_PRIVATE_TOKEN }}
```


#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)
