### PR TITLE
Use find instead of glob for changing file permissions

### DIFF
--- a/dist/steps/build.sh
+++ b/dist/steps/build.sh
@@ -158,8 +158,8 @@ chmod -R a+r "$UNITY_PROJECT_PATH"
 
 # Add execute permissions to specific files
 if [[ "$BUILD_TARGET" == "StandaloneOSX" ]]; then
-  OSX_EXECUTABLE_PATH="$BUILD_PATH_FULL/StandaloneOSX.app/Contents/MacOS/*"
-  chmod +x "$OSX_EXECUTABLE_PATH"
+  OSX_EXECUTABLE_PATH="$BUILD_PATH_FULL/$BUILD_NAME.app/Contents/MacOS"
+  find "$OSX_EXECUTABLE_PATH" -type f -exec chmod +x {} \;
 fi
 
 #


### PR DESCRIPTION
#### Changes

The build script passed the executable path to chmod inside quotes and therefore the glob patern (`.../MacOS/*`) did not get expanded by the shell. Chmod then returned an error, which you can see [here](https://github.com/game-ci/unity-builder/runs/3526626116?check_suite_focus=true#step:4:840), for example.

I changed the script to use find to locate the executable file and run chmod on it. Using find still ensures that spaces in build path or build name are handled correctly.

I also swapped `StandaloneOSX.app` with `$BUILD_NAME.app` so that the script works even if build name is changed.

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)
