### PR TITLE
Update licensing path, to be treated as temporary/invisible path

### DIFF
--- a/dist/platforms/ubuntu/entrypoint.sh
+++ b/dist/platforms/ubuntu/entrypoint.sh
@@ -4,7 +4,7 @@
 # Create directory for license activation
 #
 
-ACTIVATE_LICENSE_PATH="$GITHUB_WORKSPACE/_activate-license"
+ACTIVATE_LICENSE_PATH="$GITHUB_WORKSPACE/_activate-license~"
 mkdir -p "$ACTIVATE_LICENSE_PATH"
 
 #


### PR DESCRIPTION
This PR supersedes https://github.com/game-ci/unity-builder/pull/308 which has been inactive for a while. I've kept the author of the commit in tact.

---

if there is both a unity package and a test-project in one github repo, then the token generation process is created Library folder and then the build of the test project breaks. Requires a tilde to ignore Library folder in _activate-license.
Or need set the path ACTIVATE_LICENSE_PATH from the global ENV in runtime-action

#### Changes

- ...

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [ ] Readme (updated or not needed)
- [ ] Tests (added, updated or not needed)
