### PR TITLE
feat: compatibility with self-hosted runners with SELinux

### DIFF
--- a/src/model/docker.ts
+++ b/src/model/docker.ts
@@ -45,11 +45,9 @@ class Docker {
     switch (baseOs) {
       case 'linux':
         const github_home = join(runnerTemporaryPath, "_github_home");
-        if (!existsSync(github_home))
-          mkdirSync(github_home);
+        if (!existsSync(github_home)) mkdirSync(github_home);
         const github_workflow = join(runnerTemporaryPath, "_github_workflow");
-        if (!existsSync(github_workflow))
-          mkdirSync(github_workflow);
+        if (!existsSync(github_workflow)) mkdirSync(github_workflow);
 
         return `--env UNITY_SERIAL \
                 --env GITHUB_WORKSPACE=/github/workspace \

--- a/src/model/docker.ts
+++ b/src/model/docker.ts
@@ -45,9 +45,11 @@ class Docker {
     switch (baseOs) {
       case 'linux':
         const github_home = join(runnerTemporaryPath, "_github_home");
-        existsSync(github_home) || mkdirSync(github_home);
+        if (!existsSync(github_home))
+          mkdirSync(github_home);
         const github_workflow = join(runnerTemporaryPath, "_github_workflow");
-        existsSync(github_workflow) || mkdirSync(github_workflow);
+        if (!existsSync(github_workflow))
+          mkdirSync(github_workflow);
 
         return `--env UNITY_SERIAL \
                 --env GITHUB_WORKSPACE=/github/workspace \

--- a/src/model/docker.ts
+++ b/src/model/docker.ts
@@ -45,10 +45,10 @@ class Docker {
         return `--env UNITY_SERIAL \
                 --env GITHUB_WORKSPACE=/github/workspace \
                 ${sshAgent ? '--env SSH_AUTH_SOCK=/ssh-agent' : ''} \
-                --volume "/var/run/docker.sock":"/var/run/docker.sock" \
-                --volume "${runnerTemporaryPath}/_github_home":"/root" \
-                --volume "${runnerTemporaryPath}/_github_workflow":"/github/workflow" \
-                --volume "${workspace}":"/github/workspace" \
+                --volume "/var/run/docker.sock":"/var/run/docker.sock:z" \
+                --volume "${runnerTemporaryPath}/_github_home":"/root:z" \
+                --volume "${runnerTemporaryPath}/_github_workflow":"/github/workflow:z" \
+                --volume "${workspace}":"/github/workspace:z" \
                 ${sshAgent ? `--volume ${sshAgent}:/ssh-agent` : ''} \
                 ${sshAgent ? '--volume /home/runner/.ssh/known_hosts:/root/.ssh/known_hosts:ro' : ''}`;
       case 'win32':

--- a/src/model/docker.ts
+++ b/src/model/docker.ts
@@ -44,9 +44,9 @@ class Docker {
   static getBaseOsSpecificArguments(baseOs, workspace, unitySerial, runnerTemporaryPath, sshAgent): string {
     switch (baseOs) {
       case 'linux':
-        const github_home = join(runnerTemporaryPath, "_github_home");
+        const github_home = join(runnerTemporaryPath, '_github_home');
         if (!existsSync(github_home)) mkdirSync(github_home);
-        const github_workflow = join(runnerTemporaryPath, "_github_workflow");
+        const github_workflow = join(runnerTemporaryPath, '_github_workflow');
         if (!existsSync(github_workflow)) mkdirSync(github_workflow);
 
         return `--env UNITY_SERIAL \

--- a/src/model/docker.ts
+++ b/src/model/docker.ts
@@ -2,15 +2,15 @@ import { exec } from '@actions/exec';
 import ImageTag from './image-tag';
 import ImageEnvironmentFactory from './image-environment-factory';
 import { existsSync, mkdirSync } from 'fs';
-import { join } from 'path';
+import path from 'path';
 
 class Docker {
   static async build(buildParameters, silent = false) {
-    const { path, dockerfile, baseImage } = buildParameters;
+    const { path: buildPath, dockerfile, baseImage } = buildParameters;
     const { version, platform } = baseImage;
 
     const tag = new ImageTag({ repository: '', name: 'unity-builder', version, platform });
-    const command = `docker build ${path} \
+    const command = `docker build ${buildPath} \
       --file ${dockerfile} \
       --build-arg IMAGE=${baseImage} \
       --tag ${tag}`;
@@ -43,21 +43,22 @@ class Docker {
 
   static getBaseOsSpecificArguments(baseOs, workspace, unitySerial, runnerTemporaryPath, sshAgent): string {
     switch (baseOs) {
-      case 'linux':
-        const github_home = join(runnerTemporaryPath, '_github_home');
-        if (!existsSync(github_home)) mkdirSync(github_home);
-        const github_workflow = join(runnerTemporaryPath, '_github_workflow');
-        if (!existsSync(github_workflow)) mkdirSync(github_workflow);
+      case 'linux': {
+        const githubHome = path.join(runnerTemporaryPath, '_github_home');
+        if (!existsSync(githubHome)) mkdirSync(githubHome);
+        const githubWorkflow = path.join(runnerTemporaryPath, '_github_workflow');
+        if (!existsSync(githubWorkflow)) mkdirSync(githubWorkflow);
 
         return `--env UNITY_SERIAL \
                 --env GITHUB_WORKSPACE=/github/workspace \
                 ${sshAgent ? '--env SSH_AUTH_SOCK=/ssh-agent' : ''} \
                 --volume "/var/run/docker.sock":"/var/run/docker.sock:z" \
-                --volume "${github_home}":"/root:z" \
-                --volume "${github_workflow}":"/github/workflow:z" \
+                --volume "${githubHome}":"/root:z" \
+                --volume "${githubWorkflow}":"/github/workflow:z" \
                 --volume "${workspace}":"/github/workspace:z" \
                 ${sshAgent ? `--volume ${sshAgent}:/ssh-agent` : ''} \
                 ${sshAgent ? '--volume /home/runner/.ssh/known_hosts:/root/.ssh/known_hosts:ro' : ''}`;
+      }
       case 'win32':
         return `--env UNITY_SERIAL="${unitySerial}" \
                 --env GITHUB_WORKSPACE=c:/github/workspace \


### PR DESCRIPTION
When using a self-hosted runner with SELinux (fedora)
volumes need to be mounted with ":z" in order to have write access
these flags are documented [here](https://docs.docker.com/storage/bind-mounts/#configure-the-selinux-label)

Also the in self-hosted runners, _temp is empty, so this creates the child folders.

#### Changes

- mount volumes with SELinux labels
- create folders _github_home and _github_workflow if they are missing

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)
