### PR TITLE
Fix iOS Fastlane build when using Unity Cloud Diagnostics

### DIFF
--- a/dist/platforms/mac/steps/build.sh
+++ b/dist/platforms/mac/steps/build.sh
@@ -130,6 +130,8 @@ echo ""
   -quit \
   -batchmode \
   -nographics \
+  -username "$UNITY_EMAIL" \
+  -password "$UNITY_PASSWORD" \
   -customBuildName "$BUILD_NAME" \
   -projectPath "$UNITY_PROJECT_PATH" \
   -buildTarget "$BUILD_TARGET" \


### PR DESCRIPTION
Fixes error described here: https://forum.unity.com/threads/ios-build-is-failing-seems-like-a-fastlane-problem-not-sure-how-to-proceed.682201/

#### Changes

- Add username and password to mac build.sh

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)
