### PR TITLE
Fix for 2021.3 Mac builds

### DIFF
--- a/dist/platforms/mac/steps/build.sh
+++ b/dist/platforms/mac/steps/build.sh
@@ -126,7 +126,6 @@ echo ""
 # Reference: https://docs.unity3d.com/2019.3/Documentation/Manual/CommandLineArguments.html
 
 /Applications/Unity/Hub/Editor/$UNITY_VERSION/Unity.app/Contents/MacOS/Unity \
-  -logfile /dev/stdout \
   -quit \
   -batchmode \
   -nographics \
@@ -145,10 +144,14 @@ echo ""
   -androidKeyaliasName "$ANDROID_KEYALIAS_NAME" \
   -androidKeyaliasPass "$ANDROID_KEYALIAS_PASS" \
   -androidTargetSdkVersion "$ANDROID_TARGET_SDK_VERSION" \
-  $CUSTOM_PARAMETERS
+  $CUSTOM_PARAMETERS \
+  > "$UNITY_PROJECT_PATH/out.log" 2>&1
 
 # Catch exit code
 BUILD_EXIT_CODE=$?
+
+# Display logs
+cat "$UNITY_PROJECT_PATH/out.log"
 
 # Display results
 if [ $BUILD_EXIT_CODE -eq 0 ]; then


### PR DESCRIPTION
#### Changes

- As a workaround for an error in Mac builds on 2021.3, first write logs to file, and then display the logs afterwards: https://forum.unity.com/threads/exception-occurred-inside-beedriver.1139905/

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)
