### PR TITLE
fix: git private token not being set correctly for https

### DIFF
--- a/dist/platforms/ubuntu/steps/set_gitcredential.sh
+++ b/dist/platforms/ubuntu/steps/set_gitcredential.sh
@@ -10,7 +10,7 @@ else
 	git config --global --replace-all url."https://token:$GIT_PRIVATE_TOKEN@github.com/".insteadOf ssh://git@github.com/
 	git config --global --add url."https://token:$GIT_PRIVATE_TOKEN@github.com/".insteadOf git@github.com
 
-  git config --global url."https://token:$GIT_PRIVATE_TOKEN@github.com/".insteadOf "https://github.com/"
+  git config --global --add url."https://token:$GIT_PRIVATE_TOKEN@github.com/".insteadOf "https://github.com/"
   git config --global url."https://ssh:$GIT_PRIVATE_TOKEN@github.com/".insteadOf "ssh://git@github.com/"
   git config --global url."https://git:$GIT_PRIVATE_TOKEN@github.com/".insteadOf "git@github.com:"
 


### PR DESCRIPTION
#### Changes

 when using `gitprivatetoken`, the build logs showed an error
 ``` 
warning: ***github.com/.insteadof has multiple values
error: cannot overwrite multiple values with a single value
Use a regexp, --add or --replace-all to change ***github.com/.insteadOf. 
```
substitution url for https did not work.
this fix would add a value for https instead of overwriting it

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)
