### PR TITLE
Fix missing Android custom keystore

### DIFF
--- a/dist/default-build-script/Assets/Editor/UnityBuilderAction/Input/AndroidSettings.cs
+++ b/dist/default-build-script/Assets/Editor/UnityBuilderAction/Input/AndroidSettings.cs
@@ -10,7 +10,10 @@ namespace UnityBuilderAction.Input
     {
       EditorUserBuildSettings.buildAppBundle = options["customBuildPath"].EndsWith(".aab");
       if (options.TryGetValue("androidKeystoreName", out string keystoreName) && !string.IsNullOrEmpty(keystoreName))
+      {
+        PlayerSettings.Android.useCustomKeystore = true;
         PlayerSettings.Android.keystoreName = keystoreName;
+      }
       if (options.TryGetValue("androidKeystorePass", out string keystorePass) && !string.IsNullOrEmpty(keystorePass))
         PlayerSettings.Android.keystorePass = keystorePass;
       if (options.TryGetValue("androidKeyaliasName", out string keyaliasName) && !string.IsNullOrEmpty(keyaliasName))


### PR DESCRIPTION
#### Changes

- If a user does not set `useCustomKeystore` in their project settings, the keystore information that they input into `unity-builder` gets ignored by Unity. Therefore, we should enforce `useCustomKeystore = true` if the user inputs keystore info.

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)
