### PR TITLE
Remove v prefix from tag checking

### DIFF
--- a/dist/default-build-script/Assets/Editor/UnityBuilderAction/Versioning/Git.cs
+++ b/dist/default-build-script/Assets/Editor/UnityBuilderAction/Versioning/Git.cs
@@ -40,7 +40,7 @@ namespace UnityBuilderAction.Versioning
     /// </summary>
     public static string GetTagVersion()
     {
-      string version = Run(@"tag --points-at HEAD | grep ?[0-9]*");
+      string version = Run(@"tag --points-at HEAD | grep *[0-9]*");
 
       version = version.Substring(1);
 
@@ -62,7 +62,7 @@ namespace UnityBuilderAction.Versioning
     /// </summary>
     static bool HasAnyVersionTags()
     {
-      return "0" != Run(@"tag --list --merged HEAD | grep ?[0-9]* | wc -l");
+      return "0" != Run(@"tag --list --merged HEAD | grep *[0-9]* | wc -l");
     }
 
     /// <summary>
@@ -92,7 +92,7 @@ namespace UnityBuilderAction.Versioning
     /// </summary>
     static string GetVersionString()
     {
-      return Run(@"describe --tags --long --match ""?[0-9]*""");
+      return Run(@"describe --tags --long --match ""*[0-9]*""");
 
       // Todo - implement split function based on this more complete query
       // return Run(@"describe --long --tags --dirty --always");

--- a/dist/default-build-script/Assets/Editor/UnityBuilderAction/Versioning/Git.cs
+++ b/dist/default-build-script/Assets/Editor/UnityBuilderAction/Versioning/Git.cs
@@ -40,7 +40,7 @@ namespace UnityBuilderAction.Versioning
     /// </summary>
     public static string GetTagVersion()
     {
-      string version = Run(@"tag --points-at HEAD | grep [0-9]*");
+      string version = Run(@"tag --points-at HEAD | grep ?[0-9]*");
 
       version = version.Substring(1);
 
@@ -62,7 +62,7 @@ namespace UnityBuilderAction.Versioning
     /// </summary>
     static bool HasAnyVersionTags()
     {
-      return "0" != Run(@"tag --list --merged HEAD | grep [0-9]* | wc -l");
+      return "0" != Run(@"tag --list --merged HEAD | grep ?[0-9]* | wc -l");
     }
 
     /// <summary>
@@ -92,7 +92,7 @@ namespace UnityBuilderAction.Versioning
     /// </summary>
     static string GetVersionString()
     {
-      return Run(@"describe --tags --long --match ""[0-9]*""");
+      return Run(@"describe --tags --long --match ""?[0-9]*""");
 
       // Todo - implement split function based on this more complete query
       // return Run(@"describe --long --tags --dirty --always");

--- a/dist/default-build-script/Assets/Editor/UnityBuilderAction/Versioning/Git.cs
+++ b/dist/default-build-script/Assets/Editor/UnityBuilderAction/Versioning/Git.cs
@@ -40,7 +40,7 @@ namespace UnityBuilderAction.Versioning
     /// </summary>
     public static string GetTagVersion()
     {
-      string version = Run(@"tag --points-at HEAD | grep v[0-9]*");
+      string version = Run(@"tag --points-at HEAD | grep [0-9]*");
 
       version = version.Substring(1);
 
@@ -62,7 +62,7 @@ namespace UnityBuilderAction.Versioning
     /// </summary>
     static bool HasAnyVersionTags()
     {
-      return "0" != Run(@"tag --list --merged HEAD | grep v[0-9]* | wc -l");
+      return "0" != Run(@"tag --list --merged HEAD | grep [0-9]* | wc -l");
     }
 
     /// <summary>
@@ -92,7 +92,7 @@ namespace UnityBuilderAction.Versioning
     /// </summary>
     static string GetVersionString()
     {
-      return Run(@"describe --tags --long --match ""v[0-9]*""");
+      return Run(@"describe --tags --long --match ""[0-9]*""");
 
       // Todo - implement split function based on this more complete query
       // return Run(@"describe --long --tags --dirty --always");


### PR DESCRIPTION
### Description

There is no mention of requiring a prefix to the tags in the [documentation](https://game.ci/docs/github/builder#versioning). This is unexpected behavior, and as a result of this requirement tags such as `0.1.0` do not work with the semantic versioning strategy. Additionally, the [semantic versioning](https://semver.org) documentation referenced has not used the prefix for a couple of years.

### Changes

- Removed the requirement to have a `v` prefixing tags.