### PR TITLE
Pass Android parameters for Windows builds, fixes #434

### DIFF
--- a/dist/platforms/windows/build.ps1
+++ b/dist/platforms/windows/build.ps1
@@ -116,6 +116,12 @@ Write-Output ""
                                                                           -customBuildTarget $Env:BUILD_TARGET `
                                                                           -customBuildPath $Env:CUSTOM_BUILD_PATH `
                                                                           -buildVersion $Env:VERSION `
+                                                                          -androidVersionCode $Env:ANDROID_VERSION_CODE `
+                                                                          -androidKeystoreName $Env:ANDROID_KEYSTORE_NAME `
+                                                                          -androidKeystorePass $Env:ANDROID_KEYSTORE_PASS `
+                                                                          -androidKeyaliasName $Env:ANDROID_KEYALIAS_NAME `
+                                                                          -androidKeyaliasPass $Env:ANDROID_KEYALIAS_PASS `
+                                                                          -androidTargetSdkVersion $Env:ANDROID_TARGET_SDK_VERSION `
                                                                           $Env:CUSTOM_PARAMETERS `
                                                                           -logfile | Out-Host
 


### PR DESCRIPTION
https://github.com/game-ci/unity-builder/issues/434 will show that no Windows builds are currently capable of sending `androidVersionCode` or any other Android parameters. This can be fixed very simply by adjusting the build script to pass these parameters. Compare the following two files:

- https://github.com/game-ci/unity-builder/blob/cdee7d1d9a8ab9eccc408a37832b43d6afa73507/dist/platforms/windows/build.ps1#L112
- https://github.com/game-ci/unity-builder/blob/cdee7d1d9a8ab9eccc408a37832b43d6afa73507/dist/platforms/ubuntu/steps/build.sh#L138

It's clear that the current Windows build script is omitting certain parameters. This will resolve that issue (linked in commit message header).

#### Changes

```diff
diff --git a/dist/platforms/windows/build.ps1 b/dist/platforms/windows/build.ps1
index d6db87d..9a0aec2 100644
--- a/dist/platforms/windows/build.ps1
+++ b/dist/platforms/windows/build.ps1
@@ -116,6 +116,12 @@ Write-Output ""
                                                                           -customBuildTarget $Env:BUILD_TARGET `
                                                                           -customBuildPath $Env:CUSTOM_BUILD_PATH `
                                                                           -buildVersion $Env:VERSION `
+                                                                          -androidVersionCode $Env:ANDROID_VERSION_CODE `
+                                                                          -androidKeystoreName $Env:ANDROID_KEYSTORE_NAME `
+                                                                          -androidKeystorePass $Env:ANDROID_KEYSTORE_PASS `
+                                                                          -androidKeyaliasName $Env:ANDROID_KEYALIAS_NAME `
+                                                                          -androidKeyaliasPass $Env:ANDROID_KEYALIAS_PASS `
+                                                                          -androidTargetSdkVersion $Env:ANDROID_TARGET_SDK_VERSION `
                                                                           $Env:CUSTOM_PARAMETERS `
                                                                           -logfile | Out-Host
```

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [ ] Readme (updated or not needed)
- [ ] Tests (added, updated or not needed)
