### PR TITLE
upgrade to node 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -175,5 +175,5 @@ branding:
   icon: 'box'
   color: 'gray-dark'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
node12 actions are deprecated.
See documentation here:
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

Currently, the unity builder action gives me the following warning:
```
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: game-ci/unity-test-runner, game-ci/unity-builder
```

#### Changes

- ...

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)
