### PR TITLE
Fix: builds for Unity versions less than 2019 fail

### DIFF
--- a/dist/default-build-script/Assets/Editor/UnityBuilderAction/Input/AndroidSettings.cs
+++ b/dist/default-build-script/Assets/Editor/UnityBuilderAction/Input/AndroidSettings.cs
@@ -9,11 +9,13 @@ namespace UnityBuilderAction.Input
     public static void Apply(Dictionary<string, string> options)
     {
       EditorUserBuildSettings.buildAppBundle = options["customBuildPath"].EndsWith(".aab");
+#if UNITY_2019_1_OR_NEWER
       if (options.TryGetValue("androidKeystoreName", out string keystoreName) && !string.IsNullOrEmpty(keystoreName))
       {
         PlayerSettings.Android.useCustomKeystore = true;
         PlayerSettings.Android.keystoreName = keystoreName;
       }
+#endif
       if (options.TryGetValue("androidKeystorePass", out string keystorePass) && !string.IsNullOrEmpty(keystorePass))
         PlayerSettings.Android.keystorePass = keystorePass;
       if (options.TryGetValue("androidKeyaliasName", out string keyaliasName) && !string.IsNullOrEmpty(keyaliasName))


### PR DESCRIPTION
#### Changes

Discovered when the gameci/docker repo CI failed in [this PR](https://github.com/game-ci/docker/pull/188).

> Assets/Editor/Editor/UnityBuilderAction/Input/AndroidSettings.cs(14,32): error CS0117: 'PlayerSettings.Android' does not contain a definition for 'useCustomKeystore'

It's complaining about the line added in this [unity-builder commit](https://github.com/game-ci/unity-builder/commit/36891ec921c5f3163ea1ca6c12496c02abdaaf51) on May 21st.

```
PlayerSettings.Android.useCustomKeystore = true;
```

[useCustomKeystore](https://docs.unity3d.com/2019.3/Documentation/ScriptReference/PlayerSettings.Android-useCustomKeystore.html) was added in Unity 2019 which is why 2018 builds fail.

Might also be worth adding Unity 2018 to the [CI version list](https://github.com/game-ci/unity-builder/blob/main/.github/workflows/build-tests.yml#L21) to prevent regressions.

#### Checklist

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)
