### PR TITLE
Fix powershell quotation issue, when CUSTOM_PARAMETERS contains spaces

### DIFF
--- a/dist/platforms/windows/build.ps1
+++ b/dist/platforms/windows/build.ps1
@@ -109,6 +109,10 @@ Write-Output "#    Building project     #"
 Write-Output "###########################"
 Write-Output ""
 
+# If $Env:CUSTOM_PARAMETERS contains spaces and is passed directly on the command line to Unity, powershell will wrap it
+# in double quotes.  To avoid this, parse $Env:CUSTOM_PARAMETERS into an array, while respecting any quotations within the string.
+$_, $customParametersArray = Invoke-Expression('Write-Output -- "" ' + $Env:CUSTOM_PARAMETERS)
+
 & "C:\Program Files\Unity\Hub\Editor\$Env:UNITY_VERSION\Editor\Unity.exe" -quit -batchmode -nographics `
                                                                           -projectPath $Env:UNITY_PROJECT_PATH `
                                                                           -executeMethod $Env:BUILD_METHOD `
@@ -122,7 +126,7 @@ Write-Output ""
                                                                           -androidKeyaliasName $Env:ANDROID_KEYALIAS_NAME `
                                                                           -androidKeyaliasPass $Env:ANDROID_KEYALIAS_PASS `
                                                                           -androidTargetSdkVersion $Env:ANDROID_TARGET_SDK_VERSION `
-                                                                          $Env:CUSTOM_PARAMETERS `
+                                                                          $customParametersArray `
                                                                           -logfile | Out-Host
 
 # Catch exit code


### PR DESCRIPTION
#### Changes

Powershell inserts double-quotes around the entire $Env:CUSTOM_PARAMETERS variable when it's added to the unity command line.  This causes simple command line parsers (like the one you provide as an example) to fail, because it treats the entire custom parameters string as a single argument.

This likely affects powershell only (not bash).  This PR includes a trick to parse the CUSTOM_PARAMETERS into an array, while still respecting any individual custom parameters values that may be quoted.

Here's a simple powershell script that illustrates the problem and solution:

```powershell
# Suppose:

$Env:CUSTOM_PARAMETERS = '-customParams1 "custom value 1" -customParam2 custom_value_2'


# Current behavior:

& cmd.exe /C echo `
    -buildTarget `
    StandaloneWindows64 `
    $Env:CUSTOM_PARAMETERS `
    -logFile

# This prints:
#
# -buildTarget StandaloneWindows64 "-customParams1 "custom value 1" -customParam2 custom_value_2" -logFile
#



# Proposed solution:

$_, $customParamsArray = Invoke-Expression('Write-Output -- "" ' + $Env:CUSTOM_PARAMETERS)

& cmd.exe /C echo `
    -buildTarget `
    StandaloneWindows64 `
    $customParamsArray `
    -logFile

# This prints:
#
# -buildTarget StandaloneWindows64 -customParams1 "custom value 1" -customParam2 custom_value_2 -logFile
#
```

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)
