### PR TITLE
Fix reflection code for setting buildAppBundle

### DIFF
--- a/dist/default-build-script/Assets/Editor/UnityBuilderAction/Input/AndroidSettings.cs
+++ b/dist/default-build-script/Assets/Editor/UnityBuilderAction/Input/AndroidSettings.cs
@@ -5,7 +5,7 @@ using System.Reflection;
 
 namespace UnityBuilderAction.Input
 {
-  public class AndroidSettings
+  public static class AndroidSettings
   {
     public static void Apply(Dictionary<string, string> options)
     {
@@ -49,8 +49,8 @@ namespace UnityBuilderAction.Input
       if (options.TryGetValue("androidExportType", out androidExportType) && !string.IsNullOrEmpty(androidExportType))
       {
         // Only exists in 2018.3 and above
-        FieldInfo buildAppBundle = typeof(EditorUserBuildSettings)
-              .GetField("buildAppBundle", System.Reflection.BindingFlags.Public | BindingFlags.Instance);
+        PropertyInfo buildAppBundle = typeof(EditorUserBuildSettings)
+              .GetProperty("buildAppBundle", BindingFlags.Public | BindingFlags.Static);
         switch (androidExportType)
         {
           case "androidStudioProject":


### PR DESCRIPTION
#### Changes

- Fix reflection code for setting buildAppBundle
- Mark AndroidSettings class as static

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](https://github.com/game-ci/unity-builder/blob/main/CONTRIBUTING.md) and accept the
      [code](https://github.com/game-ci/unity-builder/blob/main/CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)
