### PR TITLE
Revert android symbol to none

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -83,7 +83,7 @@ inputs:
     description: 'The android target API level.'
   androidSymbolType:
     required: false
-    default: 'public'
+    default: 'none'
     description: 'The android symbol type to export. Should be "none", "public" or "debugging".'
   sshAgent:
     required: false


### PR DESCRIPTION
#### Changes

- Revert androidSymbolType to none

As requested in game-ci/documentation#363

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](https://github.com/game-ci/unity-builder/blob/main/CONTRIBUTING.md) and accept the
      [code](https://github.com/game-ci/unity-builder/blob/main/CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)
