### PR TITLE
Build subtarget support for Unity 2021.2+

### DIFF
--- a/dist/default-build-script/Assets/Editor/UnityBuilderAction/Builder.cs
+++ b/dist/default-build-script/Assets/Editor/UnityBuilderAction/Builder.cs
@@ -33,7 +33,7 @@ namespace UnityBuilderAction
       // Determine subtarget
       StandaloneBuildSubtarget buildSubtarget;
       if (!options.TryGetValue("standaloneBuildSubtarget", out var subtargetValue) || !Enum.TryParse(subtargetValue, out buildSubtarget)) {
-        buildSubtarget = StandaloneBuildSubtarget.NoSubtarget;
+        buildSubtarget = default;
       }
 #endif
 

--- a/dist/default-build-script/Assets/Editor/UnityBuilderAction/Builder.cs
+++ b/dist/default-build-script/Assets/Editor/UnityBuilderAction/Builder.cs
@@ -29,12 +29,23 @@ namespace UnityBuilderAction
         }
       }
 
+#if UNITY_2021_2_OR_NEWER
+      // Determine subtarget
+      StandaloneBuildSubtarget buildSubtarget;
+      if (!options.TryGetValue("standaloneBuildSubtarget", out var subtargetValue) || !Enum.TryParse(subtargetValue, out buildSubtarget)) {
+        buildSubtarget = StandaloneBuildSubtarget.NoSubtarget;
+      }
+#endif
+
       // Define BuildPlayer Options
       var buildPlayerOptions = new BuildPlayerOptions {
         scenes = scenes,
         locationPathName = options["customBuildPath"],
         target = (BuildTarget) Enum.Parse(typeof(BuildTarget), options["buildTarget"]),
-        options = buildOptions
+        options = buildOptions,
+#if UNITY_2021_2_OR_NEWER
+        subtarget = (int) buildSubtarget
+#endif
       };
 
       // Set version for this build

--- a/dist/default-build-script/Assets/Editor/UnityBuilderAction/Input/ArgumentsParser.cs
+++ b/dist/default-build-script/Assets/Editor/UnityBuilderAction/Input/ArgumentsParser.cs
@@ -28,6 +28,7 @@ namespace UnityBuilderAction.Input
       }
 
       if (!Enum.IsDefined(typeof(BuildTarget), buildTarget)) {
+        Console.WriteLine($"{buildTarget} is not a defined {nameof(BuildTarget)}");
         EditorApplication.Exit(121);
       }
 


### PR DESCRIPTION
#### Changes

- Added support for -standaloneBuildSubtarget parameter via customParameters in order to facilitate dedicated server builds. Since Unity introduced the subtarget option in 2021.2, this parameter only takes effect in supported Unity versions.

Documentation PR: https://github.com/game-ci/documentation/pull/389
Discussion: https://github.com/game-ci/documentation/issues/240

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](https://github.com/game-ci/unity-builder/blob/main/CONTRIBUTING.md) and accept the
      [code](https://github.com/game-ci/unity-builder/blob/main/CODE_OF_CONDUCT.md) of conduct
- [x] Docs (If new inputs or outputs have been added or changes to behavior that should be documented. Please make
            a PR in the [documentation repo](https://github.com/game-ci/documentation))
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)
