### PR TITLE
Removed checks for old unity versions

### DIFF
--- a/.github/workflows/build-tests-mac.yml
+++ b/.github/workflows/build-tests-mac.yml
@@ -20,15 +20,11 @@ jobs:
         projectPath:
           - test-project
         unityVersion:
-          - 2019.4.40f1 # Minimum version for IL2CPP
-          - 2020.1.17f1
-          - 2020.2.7f1
-          - 2020.3.44f1
-          - 2021.1.28f1
-          - 2021.2.19f1
-          - 2021.3.18f1
+          - 2021.3.29f1
           - 2022.1.24f1
-          - 2022.2.6f1
+          - 2022.2.21f1
+          - 2022.3.7f1
+          - 2023.1.9f1
         targetPlatform:
           - StandaloneOSX # Build a MacOS executable
 

--- a/.github/workflows/build-tests-ubuntu.yml
+++ b/.github/workflows/build-tests-ubuntu.yml
@@ -46,28 +46,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        exclude:
-          - targetPlatform: Android
-            unityVersion: 2022.2.7f1
         providerStrategy:
           # - local-docker
           - local
         projectPath:
           - test-project
         unityVersion:
-          - 2018.3.14f1
-          - 2018.4.36f1
-          - 2019.1.14f1
-          - 2019.2.21f1
-          - 2019.3.15f1
-          - 2019.4.40f1
-          - 2020.2.7f1
-          - 2020.3.45f1
-          - 2021.1.28f1
-          - 2021.2.19f1
-          - 2021.3.19f1
-          - 2022.1.24f1
-          - 2022.2.7f1
+          - 2021.3.29f1
+          - 2022.1.24f
+          - 2022.2.21f
+          - 2022.3.7f1
+          - 2023.1.9f1
         targetPlatform:
           - StandaloneOSX # Build a macOS standalone (Intel 64-bit) with mono backend.
           - StandaloneWindows64 # Build a Windows 64-bit standalone with mono backend.

--- a/.github/workflows/build-tests-windows.yml
+++ b/.github/workflows/build-tests-windows.yml
@@ -20,14 +20,11 @@ jobs:
         projectPath:
           - test-project
         unityVersion:
-          - 2019.3.15f1 # Minimum version for IL2CPP
-          - 2019.4.40f1
-          - 2020.1.17f1
-          - 2020.2.7f1
-          - 2020.3.44f1
-          - 2021.3.18f1 # 2021.1 and 2021.2 seem to have IL2CPP issues
-          - 2022.1.24f1
-          - 2022.2.6f1
+          - 2021.3.29f1
+          - 2022.1.24f
+          - 2022.2.21f
+          - 2022.3.7f1
+          - 2023.1.9f1
         targetPlatform:
           - StandaloneWindows64 # Build a Windows 64-bit standalone.
           - StandaloneWindows # Build a Windows 32-bit standalone.


### PR DESCRIPTION
#### Changes

Changed referenced EOL versions in tests to LTS and Current versions (2018.x-2020.x -> 2021.x-2023.x)

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](https://github.com/game-ci/unity-builder/blob/main/CONTRIBUTING.md) and accept the
      [code](https://github.com/game-ci/unity-builder/blob/main/CODE_OF_CONDUCT.md) of conduct
- [x] Docs (If new inputs or outputs have been added or changes to behavior that should be documented. Please make
            a PR in the [documentation repo](https://github.com/game-ci/documentation))
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)
