### PR TITLE
fix android sdkmanager invocation

### DIFF
--- a/dist/platforms/ubuntu/steps/build.sh
+++ b/dist/platforms/ubuntu/steps/build.sh
@@ -69,7 +69,15 @@ fi
 if [[ "$BUILD_TARGET" == "Android" && -n "$ANDROID_SDK_MANAGER_PARAMETERS" ]]; then
   echo "Updating Android SDK with parameters: $ANDROID_SDK_MANAGER_PARAMETERS"
   export JAVA_HOME="$(awk -F'=' '/JAVA_HOME=/{print $2}' /usr/bin/unity-editor.d/*)"
-  "$(awk -F'=' '/ANDROID_HOME=/{print $2}' /usr/bin/unity-editor.d/*)/tools/bin/sdkmanager" "$ANDROID_SDK_MANAGER_PARAMETERS"
+  ANDROID_HOME_DIRECTORY="$(awk -F'=' '/ANDROID_HOME=/{print $2}' /usr/bin/unity-editor.d/*)"
+  SDKMANAGER=$(find $ANDROID_HOME_DIRECTORY/cmdline-tools -name sdkmanager)
+  if [ -z "${SDKMANAGER}" ]
+  then
+    echo "No sdkmanager found"
+    exit 1
+  fi
+
+  $SDKMANAGER "$ANDROID_SDK_MANAGER_PARAMETERS"
   echo "Updated Android SDK."
 else
   echo "Not updating Android SDK."


### PR DESCRIPTION
#### Changes

Fix #581:

```
Exception in thread "main" java.lang.NoClassDefFoundError: javax/xml/bind/annotation/XmlSchema
 	at com.***.repository.api.SchemaModule$SchemaModuleVersion.<init>(SchemaModule.java:156)
 	at com.***.repository.api.SchemaModule.<init>(SchemaModule.java:75)
 	at com.***.sdklib.repository.AndroidSdkHandler.<clinit>(AndroidSdkHandler.java:81)
 	at com.***.sdklib.tool.sdkmanager.SdkManagerCli.main(SdkManagerCli.java:73)
	at com.***.sdklib.tool.sdkmanager.SdkManagerCli.main(SdkManagerCli.java:48)
 Caused by: java.lang.ClassNotFoundException: javax.xml.bind.annotation.XmlSchema
 	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:581)
 	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
 	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
 	... 5 more
```

The fix is to run `sdkmanager` from the `cmdline-tools` directory instead of `tools/bin` directory. The solution was suggested here:
https://stackoverflow.com/questions/46402772/failed-to-install-android-sdk-java-lang-noclassdeffounderror-javax-xml-bind-a

Tested on ubuntu runner

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](https://github.com/game-ci/unity-builder/blob/main/CONTRIBUTING.md) and accept the
      [code](https://github.com/game-ci/unity-builder/blob/main/CODE_OF_CONDUCT.md) of conduct
- [ ] Docs (If new inputs or outputs have been added or changes to behavior that should be documented. Please make
            a PR in the [documentation repo](https://github.com/game-ci/documentation))
- [ ] Readme (updated or not needed)
- [ ] Tests (added, updated or not needed)
