### PR TITLE
Ensure blank project files can be deleted by github runner

### DIFF
--- a/dist/platforms/ubuntu/entrypoint.sh
+++ b/dist/platforms/ubuntu/entrypoint.sh
@@ -21,6 +21,7 @@ source /steps/return_license.sh
 #
 
 rm -r "$ACTIVATE_LICENSE_PATH"
+chmod -R 777 "/BlankProject"
 
 #
 # Instructions for debugging


### PR DESCRIPTION
#### Changes

- chmod blank project folder to fix host permission errors

#### Related Issues

- https://github.com/game-ci/unity-builder/issues/598

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](https://github.com/game-ci/unity-builder/blob/main/CONTRIBUTING.md) and accept the
      [code](https://github.com/game-ci/unity-builder/blob/main/CODE_OF_CONDUCT.md) of conduct
- [x] Docs (If new inputs or outputs have been added or changes to behavior that should be documented. Please make a PR
      in the [documentation repo](https://github.com/game-ci/documentation))
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)
