### PR TITLE
Fix android SDK Manager Invocation on Unity 2020 and earlier versions

### DIFF
--- a/.github/workflows/build-tests-mac.yml
+++ b/.github/workflows/build-tests-mac.yml
@@ -21,6 +21,7 @@ jobs:
           - 2021.3.32f1
           - 2022.3.13f1
           - 2023.1.19f1
+          - 2023.2.2f1
         targetPlatform:
           - StandaloneOSX # Build a MacOS executable
           - iOS # Build an iOS executable

--- a/.github/workflows/build-tests-ubuntu.yml
+++ b/.github/workflows/build-tests-ubuntu.yml
@@ -50,6 +50,7 @@ jobs:
           - 2021.3.32f1
           - 2022.3.13f1
           - 2023.1.19f1
+          - 2023.2.2f1
         targetPlatform:
           - StandaloneOSX # Build a macOS standalone (Intel 64-bit) with mono backend.
           - StandaloneWindows64 # Build a Windows 64-bit standalone with mono backend.

--- a/.github/workflows/build-tests-windows.yml
+++ b/.github/workflows/build-tests-windows.yml
@@ -21,6 +21,7 @@ jobs:
           - 2021.3.32f1
           - 2022.3.13f1
           - 2023.1.19f1
+          - 2023.2.2f1
         targetPlatform:
           - Android # Build an Android apk.
           - StandaloneWindows64 # Build a Windows 64-bit standalone.

--- a/dist/platforms/ubuntu/entrypoint.sh
+++ b/dist/platforms/ubuntu/entrypoint.sh
@@ -19,8 +19,12 @@ if [[ "$BUILD_TARGET" == "Android" ]]; then
   SDKMANAGER=$(find $ANDROID_HOME_DIRECTORY/cmdline-tools -name sdkmanager)
   if [ -z "${SDKMANAGER}" ]
   then
-    echo "No sdkmanager found"
-    exit 1
+    SDKMANAGER=$(find $ANDROID_HOME_DIRECTORY/tools/bin -name sdkmanager)
+    if [ -z "${SDKMANAGER}" ]
+    then
+      echo "No sdkmanager found"
+      exit 1
+    fi
   fi
 
   if [[ -n "$ANDROID_SDK_MANAGER_PARAMETERS" ]]; then


### PR DESCRIPTION
#### Changes

- Search legacy path for android sdkmanager
- Add 2023.2 to tests

#### Related Issues

- #604 

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](https://github.com/game-ci/unity-builder/blob/main/CONTRIBUTING.md) and accept the
      [code](https://github.com/game-ci/unity-builder/blob/main/CODE_OF_CONDUCT.md) of conduct
- [x] Docs (If new inputs or outputs have been added or changes to behavior that should be documented. Please make a PR
      in the [documentation repo](https://github.com/game-ci/documentation))
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)
