### PR TITLE
Unity 2018 and .NET 3.5 support

### DIFF
--- a/dist/default-build-script/Assets/Editor/UnityBuilderAction/Builder.cs
+++ b/dist/default-build-script/Assets/Editor/UnityBuilderAction/Builder.cs
@@ -74,7 +74,7 @@ namespace UnityBuilderAction
         }
         catch (Exception e)
         {
-          Debug.LogError($"Failed to run default addressables build:\n{e}");
+          Debug.LogError("Failed to run default addressables build:\n" + e);
         }
       }
 

--- a/dist/default-build-script/Assets/Editor/UnityBuilderAction/Input/AndroidSettings.cs
+++ b/dist/default-build-script/Assets/Editor/UnityBuilderAction/Input/AndroidSettings.cs
@@ -56,17 +56,17 @@ namespace UnityBuilderAction.Input
           case "androidStudioProject":
             EditorUserBuildSettings.exportAsGoogleAndroidProject = true;
             if (buildAppBundle != null)
-              buildAppBundle.SetValue(null, false);
+              buildAppBundle.SetValue(null, false, null);
             break;
           case "androidAppBundle":
             EditorUserBuildSettings.exportAsGoogleAndroidProject = false;
             if (buildAppBundle != null)
-              buildAppBundle.SetValue(null, true);
+              buildAppBundle.SetValue(null, true, null);
             break;
           case "androidPackage":
             EditorUserBuildSettings.exportAsGoogleAndroidProject = false;
             if (buildAppBundle != null)
-              buildAppBundle.SetValue(null, false);
+              buildAppBundle.SetValue(null, false, null);
             break;
         }
       }

--- a/dist/default-build-script/Assets/Editor/UnityBuilderAction/Input/ArgumentsParser.cs
+++ b/dist/default-build-script/Assets/Editor/UnityBuilderAction/Input/ArgumentsParser.cs
@@ -28,7 +28,7 @@ namespace UnityBuilderAction.Input
       }
 
       if (!Enum.IsDefined(typeof(BuildTarget), buildTarget)) {
-        Console.WriteLine($"{buildTarget} is not a defined {nameof(BuildTarget)}");
+        Console.WriteLine(buildTarget + " is not a defined " + typeof(BuildTarget).Name);
         EditorApplication.Exit(121);
       }
 
@@ -41,10 +41,10 @@ namespace UnityBuilderAction.Input
       const string defaultCustomBuildName = "TestBuild";
       string customBuildName;
       if (!validatedOptions.TryGetValue("customBuildName", out customBuildName)) {
-        Console.WriteLine($"Missing argument -customBuildName, defaulting to {defaultCustomBuildName}.");
+        Console.WriteLine("Missing argument -customBuildName, defaulting to" + defaultCustomBuildName);
         validatedOptions.Add("customBuildName", defaultCustomBuildName);
       } else if (customBuildName == "") {
-        Console.WriteLine($"Invalid argument -customBuildName, defaulting to {defaultCustomBuildName}.");
+        Console.WriteLine("Invalid argument -customBuildName, defaulting to" + defaultCustomBuildName);
         validatedOptions.Add("customBuildName", defaultCustomBuildName);
       }
 
@@ -57,11 +57,11 @@ namespace UnityBuilderAction.Input
       string[] args = Environment.GetCommandLineArgs();
 
       Console.WriteLine(
-        $"{EOL}" +
-        $"###########################{EOL}" +
-        $"#    Parsing settings     #{EOL}" +
-        $"###########################{EOL}" +
-        $"{EOL}"
+        EOL +
+        "###########################" + EOL +
+        "#    Parsing settings     #" + EOL +
+        "###########################" + EOL +
+        EOL
       );
 
       // Extract flags with optional values
@@ -78,7 +78,7 @@ namespace UnityBuilderAction.Input
         string displayValue = secret ? "*HIDDEN*" : "\"" + value + "\"";
 
         // Assign
-        Console.WriteLine($"Found flag \"{flag}\" with value {displayValue}.");
+        Console.WriteLine("Found flag \"" + flag + "\" with value " + displayValue);
         providedArguments.Add(flag, value);
       }
     }

--- a/dist/default-build-script/Assets/Editor/UnityBuilderAction/Reporting/CompileListener.cs
+++ b/dist/default-build-script/Assets/Editor/UnityBuilderAction/Reporting/CompileListener.cs
@@ -30,7 +30,7 @@ namespace UnityBuilderAction.Reporting
                     prefix = "error";
                     break;
             }
-            Console.WriteLine($"{Environment.NewLine}::{prefix} ::{condition}{Environment.NewLine}{stackTrace}");
+            Console.WriteLine(Environment.NewLine + "::" + prefix + "::" + condition + Environment.NewLine + stackTrace);
         }
     }
 }

--- a/dist/default-build-script/Assets/Editor/UnityBuilderAction/Reporting/StdOutReporter.cs
+++ b/dist/default-build-script/Assets/Editor/UnityBuilderAction/Reporting/StdOutReporter.cs
@@ -11,16 +11,16 @@ namespace UnityBuilderAction.Reporting
     public static void ReportSummary(BuildSummary summary)
     {
       Console.WriteLine(
-        $"{EOL}" +
-        $"###########################{EOL}" +
-        $"#      Build results      #{EOL}" +
-        $"###########################{EOL}" +
-        $"{EOL}" +
-        $"Duration: {summary.totalTime.ToString()}{EOL}" +
-        $"Warnings: {summary.totalWarnings.ToString()}{EOL}" +
-        $"Errors: {summary.totalErrors.ToString()}{EOL}" +
-        $"Size: {summary.totalSize.ToString()} bytes{EOL}" +
-        $"{EOL}"
+        EOL +
+        "###########################" + EOL +
+        "#      Build results      #" + EOL +
+        "###########################" + EOL +
+        EOL +
+        "Duration: " + summary.totalTime.ToString() + EOL +
+        "Warnings: " + summary.totalWarnings.ToString() + EOL +
+        "Errors: " + summary.totalErrors.ToString() + EOL +
+        "Size: " + summary.totalSize.ToString() + " bytes" + EOL +
+        EOL
       );
     }
 

--- a/dist/default-build-script/Assets/Editor/UnityBuilderAction/Versioning/Git.cs
+++ b/dist/default-build-script/Assets/Editor/UnityBuilderAction/Versioning/Git.cs
@@ -21,11 +21,11 @@ namespace UnityBuilderAction.Versioning
         version = GetSemanticCommitVersion();
         Console.WriteLine("Repository has a valid version tag.");
       } else {
-        version = $"0.0.{GetTotalNumberOfCommits()}";
+        version = "0.0." + GetTotalNumberOfCommits();
         Console.WriteLine("Repository does not have tags to base the version on.");
       }
 
-      Console.WriteLine($"Version is {version}");
+      Console.WriteLine("Version is " + version);
 
       return version;
     }


### PR DESCRIPTION
Removed all instances of interpolated strings from editor scripts so we don't get compiler errors on old versions of .NET in Unity 2018

#### Changes

- ...

#### Related Issues

- ...

#### Related PRs

- ...

#### Successful Workflow Run Link

PRs don't have access to secrets so you will need to provide a link to a successful run of the workflows from your own
repo.

- ...

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](https://github.com/game-ci/unity-builder/blob/main/CONTRIBUTING.md) and accept the
      [code](https://github.com/game-ci/unity-builder/blob/main/CODE_OF_CONDUCT.md) of conduct
- [Not needed] Docs (If new inputs or outputs have been added or changes to behavior that should be documented. Please make a PR
      in the [documentation repo](https://github.com/game-ci/documentation))
- [Not needed] Readme (updated or not needed)
- [Not needed] Tests (added, updated or not needed)
