### PR TITLE
Fixed missing BlankProject

### DIFF
--- a/dist/platforms/mac/entrypoint.sh
+++ b/dist/platforms/mac/entrypoint.sh
@@ -14,7 +14,6 @@ if [ "$SKIP_ACTIVATION" != "true" ]; then
   fi;
 
   ACTIVATE_LICENSE_PATH="$ACTION_FOLDER/BlankProject"
-  mkdir -p "$ACTIVATE_LICENSE_PATH"
 
   source $ACTION_FOLDER/platforms/mac/steps/activate.sh
 else
@@ -33,7 +32,6 @@ source $ACTION_FOLDER/platforms/mac/steps/build.sh
 
 if [ "$SKIP_ACTIVATION" != "true" ]; then
   source $ACTION_FOLDER/platforms/mac/steps/return_license.sh
-  rm -r "$ACTIVATE_LICENSE_PATH"
 fi
 
 #


### PR DESCRIPTION
#### Changes

- Removed creation and deletion of BlankProject on Mac runners

Deleting the BlankProject on cleanup creates the following issue when calling the action multiple times in a row:
```bash
Couldn't set project path to: 

Aborting batchmode due to failure:
Couldn't set project path to: 

[Package Manager] Server::Kill -- Server was shutdown
Unclassified error occured while trying to activate license.
Exit code was: 1
Error: There was an error while trying to activate the Unity license.
Error: Build failed with exit code 1
```

There is no need to create the BlankProject as it already exists in the action.

#### Successful Workflow Run Link

This only affects self-hosted mac runners. Cannot share a workflow run here unfortunately.

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](https://github.com/game-ci/unity-builder/blob/main/CONTRIBUTING.md) and accept the
      [code](https://github.com/game-ci/unity-builder/blob/main/CODE_OF_CONDUCT.md) of conduct
- [x] Docs (If new inputs or outputs have been added or changes to behavior that should be documented. Please make a PR
      in the [documentation repo](https://github.com/game-ci/documentation))
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)
