### PR TITLE
fix(windows): replacing of urls if gitPrivateToken is set

### DIFF
--- a/dist/platforms/windows/set_gitcredential.ps1
+++ b/dist/platforms/windows/set_gitcredential.ps1
@@ -5,12 +5,12 @@ else {
     Write-Host "GIT_PRIVATE_TOKEN is set configuring git credentials"
 
     git config --global credential.helper store
-    git config --global --replace-all "url.https://token:$env:GIT_PRIVATE_TOKEN@github.com/".insteadOf "ssh://git@github.com/"
-    git config --global --add "url.https://token:$env:GIT_PRIVATE_TOKEN@github.com/".insteadOf "git@github.com"
-    git config --global --add "url.https://token:$env:GIT_PRIVATE_TOKEN@github.com/".insteadOf "https://github.com/"
+    git config --global --replace-all url."https://token:$env:GIT_PRIVATE_TOKEN@github.com/".insteadOf "ssh://git@github.com/"
+    git config --global --add url."https://token:$env:GIT_PRIVATE_TOKEN@github.com/".insteadOf "git@github.com"
+    git config --global --add url."https://token:$env:GIT_PRIVATE_TOKEN@github.com/".insteadOf "https://github.com/"
 
-    git config --global "url.https://ssh:$env:GIT_PRIVATE_TOKEN@github.com/".insteadOf "ssh://git@github.com/"
-    git config --global "url.https://git:$env:GIT_PRIVATE_TOKEN@github.com/".insteadOf "git@github.com:"
+    git config --global url."https://ssh:$env:GIT_PRIVATE_TOKEN@github.com/".insteadOf "ssh://git@github.com/"
+    git config --global url."https://git:$env:GIT_PRIVATE_TOKEN@github.com/".insteadOf "git@github.com:"
 }
 
 Write-Host "---------- git config --list -------------"


### PR DESCRIPTION
#### Changes

- Windows: fixed an error in `set_gitcredential.ps1` where `url.` was inside of the string, resulting in errors when building `with: gitPrivateToken` 

#### Related Issues

- I think right now there is none 

#### Related PRs

- I think right now there is none 

#### Successful Workflow Run Link

- This only affects private repos. Cannot share a workflow run here unfortunately.
- Comparing the changes to [linux](https://github.com/game-ci/unity-builder/blob/main/dist/platforms/ubuntu/steps/set_gitcredential.sh) might suffice.

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](https://github.com/game-ci/unity-builder/blob/main/CONTRIBUTING.md) and accept the
      [code](https://github.com/game-ci/unity-builder/blob/main/CODE_OF_CONDUCT.md) of conduct
- [x] Docs (If new inputs or outputs have been added or changes to behavior that should be documented. Please make a PR
      in the [documentation repo](https://github.com/game-ci/documentation))
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)
