### PR TITLE
Fixed bug with additional 'c:' prefix for --workDir

### DIFF
--- a/src/model/docker.ts
+++ b/src/model/docker.ts
@@ -100,7 +100,7 @@ class Docker {
     } = parameters;
 
     return `docker run \
-            --workdir c:${dockerWorkspacePath} \
+            --workdir ${dockerWorkspacePath} \
             --rm \
             ${ImageEnvironmentFactory.getEnvVarString(parameters)} \
             --env GITHUB_WORKSPACE=c:${dockerWorkspacePath} \


### PR DESCRIPTION
#### Changes

- Removed the `'c:'` prefix from the `--workDir` path for Windows hosts.

#### Related Issues

- https://github.com/game-ci/unity-builder/issues/643

#### Successful Workflow Run Link

PRs don't have access to secrets so you will need to provide a link to a successful run of the workflows from your own
repo.

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](https://github.com/game-ci/unity-builder/blob/main/CONTRIBUTING.md) and accept the
      [code](https://github.com/game-ci/unity-builder/blob/main/CODE_OF_CONDUCT.md) of conduct
- [X] Docs (If new inputs or outputs have been added or changes to behavior that should be documented. Please make a PR
      in the [documentation repo](https://github.com/game-ci/documentation))
- [X] Readme (updated or not needed)
- [X] Tests (added, updated or not needed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved compatibility of the Docker command for cross-platform usage by removing the hardcoded `C:` prefix from the workspace path.

- **Bug Fixes**
	- Enhanced flexibility in workspace path configuration, allowing for better adaptability across different environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->