### PR TITLE
fix: mock github checks in tests

### DIFF
--- a/.github/workflows/cloud-runner-ci-pipeline.yml
+++ b/.github/workflows/cloud-runner-ci-pipeline.yml
@@ -3,6 +3,11 @@ name: Cloud Runner CI Pipeline
 on:
   push: { branches: [cloud-runner-develop, cloud-runner-preview, main] }
   workflow_dispatch:
+    inputs:
+      runGithubIntegrationTests:
+        description: 'Run GitHub Checks integration tests'
+        required: false
+        default: 'false'
 
 permissions:
   checks: write
@@ -207,3 +212,20 @@ jobs:
           name: ${{ matrix.providerStrategy }} Build (${{ matrix.targetPlatform }})
           path: ${{ steps.unity-build.outputs.BUILD_ARTIFACT }}
           retention-days: 14
+
+  githubChecksIntegration:
+    name: GitHub Checks Integration
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.runGithubIntegrationTests == 'true'
+    env:
+      RUN_GITHUB_INTEGRATION_TESTS: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'yarn'
+      - run: yarn install --frozen-lockfile
+      - run: yarn test cloud-runner-github-checks-integration-test --detectOpenHandles --forceExit --runInBand
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/jest.config.js
+++ b/jest.config.js
@@ -25,6 +25,8 @@ module.exports = {
   // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
   modulePathIgnorePatterns: ['<rootDir>/lib/', '<rootDir>/dist/'],
 
+  // Files that will be run before Jest is loaded to set globals like fetch
+  setupFiles: ['<rootDir>/src/jest.globals.ts'],
   // A list of paths to modules that run some code to configure or set up the testing framework after the environment is ready
-  setupFilesAfterEnv: ['<rootDir>/src/jest.globals.ts', '<rootDir>/src/jest.setup.ts'],
+  setupFilesAfterEnv: ['<rootDir>/src/jest.setup.ts'],
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -25,6 +25,9 @@ module.exports = {
   // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
   modulePathIgnorePatterns: ['<rootDir>/lib/', '<rootDir>/dist/'],
 
-  // A list of paths to modules that run some code to configure or set up the testing framework before each test
+  // A list of paths to modules that run some code before each test file
+  setupFiles: ['<rootDir>/src/jest.globals.ts'],
+
+  // A list of paths to modules that run some code to configure or set up the testing framework after the environment is ready
   setupFilesAfterEnv: ['<rootDir>/src/jest.setup.ts'],
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -25,9 +25,6 @@ module.exports = {
   // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
   modulePathIgnorePatterns: ['<rootDir>/lib/', '<rootDir>/dist/'],
 
-  // A list of paths to modules that run some code before each test file
-  setupFiles: ['<rootDir>/src/jest.globals.ts'],
-
   // A list of paths to modules that run some code to configure or set up the testing framework after the environment is ready
-  setupFilesAfterEnv: ['<rootDir>/src/jest.setup.ts'],
+  setupFilesAfterEnv: ['<rootDir>/src/jest.globals.ts', '<rootDir>/src/jest.setup.ts'],
 };

--- a/src/integration/cloud-runner-github-checks-integration-test.ts
+++ b/src/integration/cloud-runner-github-checks-integration-test.ts
@@ -1,0 +1,39 @@
+// Integration test for exercising real GitHub check creation and updates.
+import { BuildParameters } from '../model';
+import CloudRunner from '../model/cloud-runner/cloud-runner';
+import UnityVersioning from '../model/unity-versioning';
+import { Cli } from '../model/cli/cli';
+import GitHub from '../model/github';
+import { OptionValues } from 'commander';
+
+export const TIMEOUT_INFINITE = 1e9;
+
+async function createParameters(overrides?: OptionValues) {
+  if (overrides) Cli.options = overrides;
+
+  return BuildParameters.create();
+}
+
+const runIntegration = process.env.RUN_GITHUB_INTEGRATION_TESTS === 'true';
+const describeOrSkip = runIntegration ? describe : describe.skip;
+
+describeOrSkip('Cloud Runner Github Checks Integration', () => {
+  it(
+    'creates and updates a real GitHub check',
+    async () => {
+      const buildParameter = await createParameters({
+        versioning: 'None',
+        projectPath: 'test-project',
+        unityVersion: UnityVersioning.read('test-project'),
+        asyncCloudRunner: `true`,
+        githubChecks: `true`,
+      });
+      await CloudRunner.setup(buildParameter);
+      const checkId = await GitHub.createGitHubCheck(`integration create`);
+      expect(checkId).not.toEqual('');
+      await GitHub.updateGitHubCheck(`1 ${new Date().toISOString()}`, `integration`);
+      await GitHub.updateGitHubCheck(`2 ${new Date().toISOString()}`, `integration`, `success`, `completed`);
+    },
+    TIMEOUT_INFINITE,
+  );
+});

--- a/src/integration/cloud-runner-github-checks-integration-test.ts
+++ b/src/integration/cloud-runner-github-checks-integration-test.ts
@@ -1,18 +1,8 @@
 // Integration test for exercising real GitHub check creation and updates.
-import { BuildParameters } from '../model';
 import CloudRunner from '../model/cloud-runner/cloud-runner';
 import UnityVersioning from '../model/unity-versioning';
-import { Cli } from '../model/cli/cli';
 import GitHub from '../model/github';
-import { OptionValues } from 'commander';
-
-export const TIMEOUT_INFINITE = 1e9;
-
-async function createParameters(overrides?: OptionValues) {
-  if (overrides) Cli.options = overrides;
-
-  return BuildParameters.create();
-}
+import { TIMEOUT_INFINITE, createParameters } from '../test-utils/cloud-runner-test-helpers';
 
 const runIntegration = process.env.RUN_GITHUB_INTEGRATION_TESTS === 'true';
 const describeOrSkip = runIntegration ? describe : describe.skip;

--- a/src/jest.globals.ts
+++ b/src/jest.globals.ts
@@ -1,0 +1,3 @@
+import { fetch as undiciFetch, Headers, Request, Response } from 'undici';
+
+Object.assign(globalThis, { fetch: undiciFetch, Headers, Request, Response });

--- a/src/model/cloud-runner/tests/cloud-runner-github-checks.test.ts
+++ b/src/model/cloud-runner/tests/cloud-runner-github-checks.test.ts
@@ -2,7 +2,6 @@ import { BuildParameters } from '../..';
 import CloudRunner from '../cloud-runner';
 import UnityVersioning from '../../unity-versioning';
 import { Cli } from '../../cli/cli';
-import CloudRunnerOptions from '../options/cloud-runner-options';
 import setups from './cloud-runner-suite.test';
 import { OptionValues } from 'commander';
 import GitHub from '../../github';
@@ -16,44 +15,59 @@ describe('Cloud Runner Github Checks', () => {
   setups();
   it('Responds', () => {});
 
-  if (CloudRunnerOptions.cloudRunnerDebug) {
-    it(
-      'Check Handling Direct',
-      async () => {
-        // Setup parameters
-        const buildParameter = await CreateParameters({
-          versioning: 'None',
-          projectPath: 'test-project',
-          unityVersion: UnityVersioning.read('test-project'),
-          asyncCloudRunner: `true`,
-          githubChecks: `true`,
-        });
-        await CloudRunner.setup(buildParameter);
-        CloudRunner.buildParameters.githubCheckId = await GitHub.createGitHubCheck(`direct create`);
-        await GitHub.updateGitHubCheck(`1 ${new Date().toISOString()}`, `direct`);
-        await GitHub.updateGitHubCheck(`2 ${new Date().toISOString()}`, `direct`, `success`, `completed`);
-      },
-      TIMEOUT_INFINITE,
-    );
-    it(
-      'Check Handling Via Async Workflow',
-      async () => {
-        // Setup parameters
-        const buildParameter = await CreateParameters({
-          versioning: 'None',
-          projectPath: 'test-project',
-          unityVersion: UnityVersioning.read('test-project'),
-          asyncCloudRunner: `true`,
-          githubChecks: `true`,
-        });
-        GitHub.forceAsyncTest = true;
-        await CloudRunner.setup(buildParameter);
-        CloudRunner.buildParameters.githubCheckId = await GitHub.createGitHubCheck(`async create`);
-        await GitHub.updateGitHubCheck(`1 ${new Date().toISOString()}`, `async`);
-        await GitHub.updateGitHubCheck(`2 ${new Date().toISOString()}`, `async`, `success`, `completed`);
-        GitHub.forceAsyncTest = false;
-      },
-      TIMEOUT_INFINITE,
-    );
-  }
+  beforeEach(() => {
+    // Mock GitHub API requests to avoid real network calls
+    jest.spyOn(GitHub as any, 'createGitHubCheckRequest').mockResolvedValue({
+      status: 201,
+      data: { id: '1' },
+    });
+    jest.spyOn(GitHub as any, 'updateGitHubCheckRequest').mockResolvedValue({
+      status: 200,
+      data: {},
+    });
+    jest.spyOn(GitHub as any, 'runUpdateAsyncChecksWorkflow').mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it(
+    'Check Handling Direct',
+    async () => {
+      // Setup parameters
+      const buildParameter = await CreateParameters({
+        versioning: 'None',
+        projectPath: 'test-project',
+        unityVersion: UnityVersioning.read('test-project'),
+        asyncCloudRunner: `true`,
+        githubChecks: `true`,
+      });
+      await CloudRunner.setup(buildParameter);
+      CloudRunner.buildParameters.githubCheckId = await GitHub.createGitHubCheck(`direct create`);
+      await GitHub.updateGitHubCheck(`1 ${new Date().toISOString()}`, `direct`);
+      await GitHub.updateGitHubCheck(`2 ${new Date().toISOString()}`, `direct`, `success`, `completed`);
+    },
+    TIMEOUT_INFINITE,
+  );
+  it(
+    'Check Handling Via Async Workflow',
+    async () => {
+      // Setup parameters
+      const buildParameter = await CreateParameters({
+        versioning: 'None',
+        projectPath: 'test-project',
+        unityVersion: UnityVersioning.read('test-project'),
+        asyncCloudRunner: `true`,
+        githubChecks: `true`,
+      });
+      GitHub.forceAsyncTest = true;
+      await CloudRunner.setup(buildParameter);
+      CloudRunner.buildParameters.githubCheckId = await GitHub.createGitHubCheck(`async create`);
+      await GitHub.updateGitHubCheck(`1 ${new Date().toISOString()}`, `async`);
+      await GitHub.updateGitHubCheck(`2 ${new Date().toISOString()}`, `async`, `success`, `completed`);
+      GitHub.forceAsyncTest = false;
+    },
+    TIMEOUT_INFINITE,
+  );
 });

--- a/src/model/cloud-runner/tests/cloud-runner-github-checks.test.ts
+++ b/src/model/cloud-runner/tests/cloud-runner-github-checks.test.ts
@@ -1,16 +1,8 @@
-import { BuildParameters } from '../..';
 import CloudRunner from '../cloud-runner';
 import UnityVersioning from '../../unity-versioning';
-import { Cli } from '../../cli/cli';
 import setups from './cloud-runner-suite.test';
-import { OptionValues } from 'commander';
 import GitHub from '../../github';
-export const TIMEOUT_INFINITE = 1e9;
-async function CreateParameters(overrides: OptionValues | undefined) {
-  if (overrides) Cli.options = overrides;
-
-  return BuildParameters.create();
-}
+import { TIMEOUT_INFINITE, createParameters } from '../../../test-utils/cloud-runner-test-helpers';
 describe('Cloud Runner Github Checks', () => {
   setups();
   it('Responds', () => {});
@@ -36,7 +28,7 @@ describe('Cloud Runner Github Checks', () => {
     'Check Handling Direct',
     async () => {
       // Setup parameters
-      const buildParameter = await CreateParameters({
+      const buildParameter = await createParameters({
         versioning: 'None',
         projectPath: 'test-project',
         unityVersion: UnityVersioning.read('test-project'),
@@ -54,7 +46,7 @@ describe('Cloud Runner Github Checks', () => {
     'Check Handling Via Async Workflow',
     async () => {
       // Setup parameters
-      const buildParameter = await CreateParameters({
+      const buildParameter = await createParameters({
         versioning: 'None',
         projectPath: 'test-project',
         unityVersion: UnityVersioning.read('test-project'),

--- a/src/test-utils/cloud-runner-test-helpers.ts
+++ b/src/test-utils/cloud-runner-test-helpers.ts
@@ -1,0 +1,10 @@
+import { BuildParameters } from '../model';
+import { Cli } from '../model/cli/cli';
+import { OptionValues } from 'commander';
+
+export const TIMEOUT_INFINITE = 1e9;
+
+export async function createParameters(overrides?: OptionValues) {
+  if (overrides) Cli.options = overrides;
+  return BuildParameters.create();
+}

--- a/src/test-utils/cloud-runner-test-helpers.ts
+++ b/src/test-utils/cloud-runner-test-helpers.ts
@@ -6,5 +6,6 @@ export const TIMEOUT_INFINITE = 1e9;
 
 export async function createParameters(overrides?: OptionValues) {
   if (overrides) Cli.options = overrides;
+
   return BuildParameters.create();
 }


### PR DESCRIPTION
Improving stability/fix for occasional fail on a test for coordinator/cloud runner.

Mocks a github check API which very occasionally fails.

## Summary
- polyfill fetch using undici for jest, loading it before test files
- mock github check requests to avoid network dependency in tests
- format cloud runner github checks test to satisfy prettier
- always mock github check requests, removing debug guard
- add optional github check integration test and parameterized workflow
- rename GitHub checks integration test file to satisfy lint naming rules
- document the GitHub checks integration test

## Testing
- `npx prettier src/integration/cloud-runner-github-checks-integration-test.ts .github/workflows/cloud-runner-ci-pipeline.yml src/jest.setup.ts src/jest.globals.ts src/model/cloud-runner/tests/cloud-runner-github-checks.test.ts jest.config.js --check`
- `npx eslint src/**/*.ts` *(fails: ESLint couldn't find the @typescript-eslint/eslint-plugin package)*
- `cloudRunnerTests=true yarn run test "cloud-runner-github-checks" --detectOpenHandles --forceExit --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_688e58da43948324b6030b044d3e3ec9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional manual workflow trigger to run GitHub integration tests.
  * Introduced a new integration test for Cloud Runner GitHub Checks.

* **Tests**
  * Enhanced Jest configuration to support global setup files.
  * Added integration and unit tests for GitHub Checks functionality.
  * Improved test isolation by mocking GitHub API requests.
  * Added test helpers to streamline build parameter creation with overrides.

* **Chores**
  * Polyfilled global fetch and related APIs using the undici library for test environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->