### PR TITLE
fix: ensure github runner service starts on windows

### DIFF
--- a/scripts/game-ci.bat
+++ b/scripts/game-ci.bat
@@ -13,3 +13,13 @@ if exist %UserProfile%\AppData\LocalLow\game-ci\ (
 
 call yarn --cwd %UserProfile%\AppData\LocalLow\game-ci\ install
 call yarn --cwd %UserProfile%\AppData\LocalLow\game-ci\ run gcp-secrets-cli %* --projectPath %cd% --awsStackName game-ci-cli
+
+REM Ensure GitHub Actions runner service is installed and running
+if exist "%UserProfile%\actions-runner\svc.bat" (
+  call "%UserProfile%\actions-runner\svc.bat" status >nul 2>&1
+  if errorlevel 1 (
+    echo Installing and starting GitHub Actions runner service
+    call "%UserProfile%\actions-runner\svc.bat" install
+    call "%UserProfile%\actions-runner\svc.bat" start
+  )
+)


### PR DESCRIPTION
## Summary
- ensure windows setup script auto-starts GitHub Actions runner service

## Testing
- `npx -y yarn@1.22.19 test`

------
https://chatgpt.com/codex/tasks/task_e_68bc866888288324816872dc501b1bd8