### PR TITLE
fix: compile error on Unity 2021.2 or earlier

### DIFF
--- a/dist/default-build-script/Assets/Editor/UnityBuilderAction/Input/AndroidSettings.cs
+++ b/dist/default-build-script/Assets/Editor/UnityBuilderAction/Input/AndroidSettings.cs
@@ -115,6 +115,7 @@ namespace UnityBuilderAction.Input
       }
     }
 
+#if UNITY_6000_0_OR_NEWER
     private static void SetDebugSymbols(string enumValueName)
     {
       // UnityEditor.Android.UserBuildSettings and Unity.Android.Types.DebugSymbolLevel are part of the Unity Android module.
@@ -144,5 +145,6 @@ namespace UnityBuilderAction.Input
       }
       levelProp.SetValue(null, enumValue);
     }
+#endif
   }
 }


### PR DESCRIPTION
#### Changes

- `Enum.TryParse(Type, string, bool, out Enum)` method requires .netstandard 2.1
- The `SetDebugSymbols` method is only used within the `#if UNITY_6000_0_OR_NEWER - #elif` section.

#### Related Issues

- #752

#### Related PRs

- 

#### Successful Workflow Run Link

PRs don't have access to secrets so you will need to provide a link to a successful run of the workflows from your own
repo.

- Builds - Windows: https://github.com/mob-sakai/unity-builder/actions/runs/18431406693
- Builds - Ubuntu: https://github.com/mob-sakai/unity-builder/actions/runs/18431406705
- Builds - MacOS: https://github.com/mob-sakai/unity-builder/actions/runs/18431406700


#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](https://github.com/game-ci/unity-builder/blob/main/CONTRIBUTING.md) and accept the
      [code](https://github.com/game-ci/unity-builder/blob/main/CODE_OF_CONDUCT.md) of conduct
- [x] Docs (If new inputs or outputs have been added or changes to behavior that should be documented. Please make a PR
      in the [documentation repo](https://github.com/game-ci/documentation))
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)
