### PR TITLE
Ensures Visual C++ Redistributables for 2013 is installed

### DIFF
--- a/dist/platforms/windows/entrypoint.ps1
+++ b/dist/platforms/windows/entrypoint.ps1
@@ -18,6 +18,9 @@ regsvr32 C:\ProgramData\Microsoft\VisualStudio\Setup\x64\Microsoft.VisualStudio.
 # Kill the regsvr process
 Get-Process -Name regsvr32 | ForEach-Object { Stop-Process -Id $_.Id -Force }
 
+# Install Visual C++ 2013 Redistributables
+. "c:\steps\install_vcredist13.ps1"
+
 # Setup Git Credentials
 . "c:\steps\set_gitcredential.ps1"
 

--- a/dist/platforms/windows/install_vcredist13.ps1
+++ b/dist/platforms/windows/install_vcredist13.ps1
@@ -1,0 +1,11 @@
+# For some reason, Unity is failing in github actions windows runners
+# due to missing Visual C++ 2013 redistributables.
+# This script downloads and installs the required redistributables.
+Write-Output ""
+Write-Output "#########################################################"
+Write-Output "#     Installing Visual C++ Redistributables (2013)     #"
+Write-Output "#########################################################"
+Write-Output ""
+
+
+choco install vcredist2013 -y --no-progress


### PR DESCRIPTION
#### Changes

- Adds a script to make sure Visual C++ Redistributables 2013 is installed in the machine, so Unity.exe can be launched
- Calls said method from entrypoint.ps1

#### Notes
I wasn't able to detect the 2013 Redistributables being present in the current `windows-latest` github runner image. But [they specify that those should be available in the image](https://github.com/actions/runner-images/blob/main/images/windows/Windows2025-Readme.md#microsoft-visual-c).
I am suspecting there might be an issue with the current runner image for windows 🤔 

In any case, this should solve the issue for now until a better fix is found

These are the redistributables I can find in when running on windows-latest
```
Checking installed Visual C++ Redistributables via registry
----
DisplayName    : Microsoft Visual C++ 2015-2022 Redistributable (x64) - 
                 14.38.33135
DisplayVersion : 14.38.33135.0
----
DisplayName    : Microsoft Visual C++ 2015-2022 Redistributable (x86) - 
                 14.38.33135
DisplayVersion : 14.38.33135.0
----
DisplayName    : Microsoft Visual C++ 2022 X64 Additional Runtime - 14.38.33135
DisplayVersion : 14.38.33135
----
DisplayName    : Microsoft Visual C++ 2022 X64 Minimum Runtime - 14.38.33135
DisplayVersion : 14.38.33135
----
DisplayName    : Microsoft Visual C++ 2022 X86 Additional Runtime - 14.38.33135
DisplayVersion : 14.38.33135
----
DisplayName    : Microsoft Visual C++ 2022 X86 Minimum Runtime - 14.38.33135
DisplayVersion : 14.38.33135
```

#### Successful Workflow Run Link

It's not fully successful, but you can see the Activation and Build did finish in this repo of a plugin I maintain
- https://github.com/lupidan/apple-signin-unity/actions/runs/18732263279/job/53431717750


- [x] Read the contribution [guide](https://github.com/game-ci/unity-builder/blob/main/CONTRIBUTING.md) and accept the
      [code](https://github.com/game-ci/unity-builder/blob/main/CODE_OF_CONDUCT.md) of conduct
- [X] Docs - not needed
- [X] Readme - not needed
- [X] Tests - not needed
