### PR TITLE
Simplify build profile loading logic

### DIFF
--- a/dist/default-build-script/Assets/Editor/UnityBuilderAction/Builder.cs
+++ b/dist/default-build-script/Assets/Editor/UnityBuilderAction/Builder.cs
@@ -66,10 +66,6 @@ namespace UnityBuilderAction
         var buildProfile = AssetDatabase.LoadAssetAtPath<BuildProfile>(buildProfilePath)
                            ?? throw new Exception("Build profile file not found at path: " + buildProfilePath);
 
-#if !BUILD_PROFILE_LOADED
-        throw new Exception("Build profile's define symbol not present before script execution; shouldn't happen");
-#endif // BUILD_PROFILE_LOADED
-
         // no need to set active profile, as already set by `-activeBuildProfile` CLI argument
         // BuildProfile.SetActiveBuildProfile(buildProfile);
         Debug.Log($"build profile: {buildProfile.name}");


### PR DESCRIPTION
#### Changes

- Removed unnecessary check for build profile define symbol.

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](https://github.com/game-ci/unity-builder/blob/main/CONTRIBUTING.md) and accept the
      [code](https://github.com/game-ci/unity-builder/blob/main/CODE_OF_CONDUCT.md) of conduct
- [x] Docs (If new inputs or outputs have been added or changes to behavior that should be documented. Please make a PR
      in the [documentation repo](https://github.com/game-ci/documentation))
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)
