### PR TITLE
feat: sync secrets workflow for sibling repositories

### DIFF
--- a/.github/workflows/sync-secrets.yml
+++ b/.github/workflows/sync-secrets.yml
@@ -1,0 +1,81 @@
+name: Sync Secrets to Repositories
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_repo:
+        description: 'Target repository (org/repo format)'
+        required: true
+        default: 'game-ci/orchestrator'
+        type: choice
+        options:
+          - game-ci/orchestrator
+          - game-ci/cli
+      dry_run:
+        description: 'Dry run (list secrets to sync without writing)'
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  sync-secrets:
+    name: Sync secrets to ${{ inputs.target_repo }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Sync secrets
+        env:
+          GH_TOKEN: ${{ secrets.GIT_PRIVATE_TOKEN }}
+          TARGET_REPO: ${{ inputs.target_repo }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          # Secrets to sync — values come from repo + org secrets available here
+          SECRET_UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          SECRET_UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+          SECRET_UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
+          SECRET_GIT_PRIVATE_TOKEN: ${{ secrets.GIT_PRIVATE_TOKEN }}
+          SECRET_LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
+          SECRET_GOOGLE_SERVICE_ACCOUNT_EMAIL: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_EMAIL }}
+          SECRET_GOOGLE_SERVICE_ACCOUNT_KEY: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_KEY }}
+          SECRET_CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        run: |
+          SECRETS=(
+            "UNITY_EMAIL:SECRET_UNITY_EMAIL"
+            "UNITY_PASSWORD:SECRET_UNITY_PASSWORD"
+            "UNITY_SERIAL:SECRET_UNITY_SERIAL"
+            "GIT_PRIVATE_TOKEN:SECRET_GIT_PRIVATE_TOKEN"
+            "LOCALSTACK_AUTH_TOKEN:SECRET_LOCALSTACK_AUTH_TOKEN"
+            "GOOGLE_SERVICE_ACCOUNT_EMAIL:SECRET_GOOGLE_SERVICE_ACCOUNT_EMAIL"
+            "GOOGLE_SERVICE_ACCOUNT_KEY:SECRET_GOOGLE_SERVICE_ACCOUNT_KEY"
+            "CODECOV_TOKEN:SECRET_CODECOV_TOKEN"
+          )
+
+          synced=0
+          skipped=0
+
+          for entry in "${SECRETS[@]}"; do
+            name="${entry%%:*}"
+            env_var="${entry##*:}"
+            value="${!env_var}"
+
+            if [ -z "$value" ]; then
+              echo "⏭ SKIP: $name (not available in this repo's context)"
+              skipped=$((skipped + 1))
+              continue
+            fi
+
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "🔍 DRY RUN: would sync $name → $TARGET_REPO"
+            else
+              echo "$value" | gh secret set "$name" -R "$TARGET_REPO" --body -
+              echo "✅ SYNCED: $name → $TARGET_REPO"
+            fi
+            synced=$((synced + 1))
+          done
+
+          echo ""
+          echo "=== Summary ==="
+          echo "Synced: $synced"
+          echo "Skipped (not available): $skipped"
+          echo "Target: $TARGET_REPO"
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "Mode: DRY RUN (no secrets were written)"
+          fi


### PR DESCRIPTION
## Summary
- Adds a manually-triggered workflow (`sync-secrets.yml`) that copies secrets from unity-builder to sibling repos (orchestrator, cli)
- Uses `GIT_PRIVATE_TOKEN` for cross-repo GitHub API access via `gh secret set`
- Supports dry-run mode to preview what would be synced without writing
- Skips secrets not available in this repo's context (repo + org level)

## Secrets synced
| Secret | Used by |
|--------|---------|
| `UNITY_EMAIL` | Orchestrator integration tests |
| `UNITY_PASSWORD` | Orchestrator integration tests |
| `UNITY_SERIAL` | Orchestrator integration tests |
| `GIT_PRIVATE_TOKEN` | Orchestrator CI (git operations) |
| `LOCALSTACK_AUTH_TOKEN` | Orchestrator LocalStack integration tests |
| `GOOGLE_SERVICE_ACCOUNT_EMAIL` | GCP provider tests |
| `GOOGLE_SERVICE_ACCOUNT_KEY` | GCP provider tests |
| `CODECOV_TOKEN` | Code coverage reporting |

## Usage
1. Go to Actions → "Sync Secrets to Repositories"
2. Select target repo (orchestrator or cli)
3. Optionally enable dry run
4. Click "Run workflow"

## Context
The orchestrator repo has zero secrets configured, causing all LocalStack-based integration tests to fail. This workflow provides a convenient way to keep secrets in sync across game-ci repos without manual copying.

> **Note**: `LOCALSTACK_AUTH_TOKEN` must first be added to unity-builder (or as an org secret) before it can be synced. LocalStack v4+ requires this token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new manual workflow for syncing secrets across repositories, including a dry-run mode for previewing changes before applying them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->