### PR TITLE
Adds support for useHostNetwork the unity-builder

### DIFF
--- a/.github/workflows/build-tests-mac.yml
+++ b/.github/workflows/build-tests-mac.yml
@@ -18,9 +18,9 @@ jobs:
         projectPath:
           - test-project
         unityVersion:
-          - 2021.3.45f1
-          - 2022.3.13f1
-          - 2023.2.2f1
+          - 2021.3.45f2
+          - 2022.3.62f3
+          - 2023.2.22f1
         targetPlatform:
           - StandaloneOSX # Build a MacOS executable
           - iOS # Build an iOS executable

--- a/.github/workflows/build-tests-ubuntu.yml
+++ b/.github/workflows/build-tests-ubuntu.yml
@@ -48,9 +48,9 @@ jobs:
         projectPath:
           - test-project
         unityVersion:
-          - 2021.3.32f1
-          - 2022.3.13f1
-          - 2023.2.2f1
+          - 2021.3.45f2
+          - 2022.3.62f3
+          - 2023.2.22f1
         targetPlatform:
           - StandaloneOSX # Build a macOS standalone (Intel 64-bit) with mono backend.
           - StandaloneWindows64 # Build a Windows 64-bit standalone with mono backend.

--- a/.github/workflows/build-tests-windows.yml
+++ b/.github/workflows/build-tests-windows.yml
@@ -18,9 +18,9 @@ jobs:
         projectPath:
           - test-project
         unityVersion:
-          - 2021.3.32f1
-          - 2022.3.13f1
-          - 2023.2.2f1
+          - 2021.3.45f2
+          - 2022.3.62f3
+          - 2023.2.22f1
         targetPlatform:
           - Android # Build an Android apk.
           - StandaloneWindows64 # Build a Windows 64-bit standalone.

--- a/.github/workflows/validate-orchestrator-integration.yml
+++ b/.github/workflows/validate-orchestrator-integration.yml
@@ -21,9 +21,9 @@ permissions:
   checks: write
   statuses: write
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+# Note: no concurrency block here — when invoked via workflow_call, the caller
+# (integrity-check.yml) manages concurrency. For direct dispatch/cron, runs are
+# naturally serialized by GitHub's single-concurrency-per-ref default.
 
 env:
   AWS_STACK_NAME: game-ci-team-pipelines

--- a/action.yml
+++ b/action.yml
@@ -47,6 +47,10 @@ inputs:
     required: false
     default: ''
     description: 'Custom parameters to configure the build.'
+  useHostNetwork:
+    required: false
+    default: false
+    description: 'Initialises Docker using the host network. (Linux only)'
   versioning:
     required: false
     default: 'Semantic'

--- a/dist/index.js
+++ b/dist/index.js
@@ -327,6 +327,7 @@ class BuildParameters {
             androidExportType: input_1.default.androidExportType,
             androidSymbolType: androidSymbolExportType,
             customParameters: input_1.default.customParameters,
+            useHostNetwork: input_1.default.useHostNetwork,
             sshAgent: input_1.default.sshAgent,
             sshPublicKeysDirectoryPath: input_1.default.sshPublicKeysDirectoryPath,
             gitPrivateToken: input_1.default.gitPrivateToken ?? (await github_cli_1.GithubCliReader.GetGitHubAuthToken()),
@@ -637,7 +638,7 @@ class Docker {
         return await (0, exec_1.exec)(runCommand, undefined, options);
     }
     static getLinuxCommand(image, parameters, overrideCommands = '', additionalVariables = [], entrypointBash = false) {
-        const { workspace, actionFolder, runnerTempPath, sshAgent, sshPublicKeysDirectoryPath, gitPrivateToken, dockerWorkspacePath, dockerCpuLimit, dockerMemoryLimit, } = parameters;
+        const { workspace, actionFolder, useHostNetwork, runnerTempPath, sshAgent, sshPublicKeysDirectoryPath, gitPrivateToken, dockerWorkspacePath, dockerCpuLimit, dockerMemoryLimit, } = parameters;
         const githubHome = node_path_1.default.join(runnerTempPath, '_github_home');
         if (!(0, node_fs_1.existsSync)(githubHome))
             (0, node_fs_1.mkdirSync)(githubHome);
@@ -670,6 +671,7 @@ class Docker {
             ? '--volume /home/runner/.ssh/known_hosts:/root/.ssh/known_hosts:ro'
             : ''} \
             ${sshPublicKeysDirectoryPath ? `--volume ${sshPublicKeysDirectoryPath}:/root/.ssh:ro` : ''} \
+            ${useHostNetwork ? '--net=host' : ''} \
             ${entrypointBash ? `--entrypoint ${commandPrefix}` : ``} \
             ${image} \
             ${entrypointBash ? `-c` : `${commandPrefix} -c`} \
@@ -1381,6 +1383,10 @@ class Input {
     }
     static get customParameters() {
         return Input.getInput('customParameters') ?? '';
+    }
+    static get useHostNetwork() {
+        const input = Input.getInput('useHostNetwork') ?? false;
+        return input === 'true';
     }
     static get versioningStrategy() {
         return Input.getInput('versioning') ?? 'Semantic';

--- a/src/model/build-parameters.test.ts
+++ b/src/model/build-parameters.test.ts
@@ -219,5 +219,10 @@ describe('BuildParameters', () => {
       jest.spyOn(Input, 'customParameters', 'get').mockReturnValue(mockValue);
       await expect(BuildParameters.create()).resolves.toEqual(expect.objectContaining({ customParameters: mockValue }));
     });
+
+    it.each([true, false])('returns the flag for useHostNetwork when %s', async (mockValue) => {
+      jest.spyOn(Input, 'useHostNetwork', 'get').mockReturnValue(mockValue);
+      await expect(BuildParameters.create()).resolves.toEqual(expect.objectContaining({ useHostNetwork: mockValue }));
+    });
   });
 });

--- a/src/model/build-parameters.ts
+++ b/src/model/build-parameters.ts
@@ -47,6 +47,7 @@ class BuildParameters {
   public containerRegistryImageVersion!: string;
 
   public customParameters!: string;
+  public useHostNetwork!: boolean;
   public sshAgent!: string;
   public sshPublicKeysDirectoryPath!: string;
   public providerStrategy!: string;
@@ -141,6 +142,7 @@ class BuildParameters {
       androidExportType: Input.androidExportType,
       androidSymbolType: androidSymbolExportType,
       customParameters: Input.customParameters,
+      useHostNetwork: Input.useHostNetwork,
       sshAgent: Input.sshAgent,
       sshPublicKeysDirectoryPath: Input.sshPublicKeysDirectoryPath,
       gitPrivateToken: Input.gitPrivateToken ?? (await GithubCliReader.GetGitHubAuthToken()),

--- a/src/model/docker.ts
+++ b/src/model/docker.ts
@@ -42,6 +42,7 @@ class Docker {
     const {
       workspace,
       actionFolder,
+      useHostNetwork,
       runnerTempPath,
       sshAgent,
       sshPublicKeysDirectoryPath,
@@ -85,6 +86,7 @@ class Docker {
                 : ''
             } \
             ${sshPublicKeysDirectoryPath ? `--volume ${sshPublicKeysDirectoryPath}:/root/.ssh:ro` : ''} \
+            ${useHostNetwork ? '--net=host' : ''} \
             ${entrypointBash ? `--entrypoint ${commandPrefix}` : ``} \
             ${image} \
             ${entrypointBash ? `-c` : `${commandPrefix} -c`} \

--- a/src/model/input.test.ts
+++ b/src/model/input.test.ts
@@ -334,4 +334,22 @@ describe('Input', () => {
       expect(spy).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe('useHostNetwork', () => {
+    it('returns the default value', () => {
+      expect(Input.useHostNetwork).toStrictEqual(false);
+    });
+
+    it('returns true when string true is passed', () => {
+      const spy = jest.spyOn(core, 'getInput').mockReturnValue('true');
+      expect(Input.useHostNetwork).toStrictEqual(true);
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns false when string false is passed', () => {
+      const spy = jest.spyOn(core, 'getInput').mockReturnValue('false');
+      expect(Input.useHostNetwork).toStrictEqual(false);
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/src/model/input.ts
+++ b/src/model/input.ts
@@ -139,6 +139,12 @@ class Input {
     return Input.getInput('customParameters') ?? '';
   }
 
+  static get useHostNetwork(): boolean {
+    const input = Input.getInput('useHostNetwork') ?? false;
+
+    return input === 'true';
+  }
+
   static get versioningStrategy(): string {
     return Input.getInput('versioning') ?? 'Semantic';
   }


### PR DESCRIPTION
#### Changes

- Adds optional useHostNetwork to action (to match [unity's test runner](https://github.com/game-ci/unity-test-runner/blob/9e9fb99c451e4598ac9d0dcae1932a7e6384555f/action.yml#L31))
- Adds useHostNetwork to Input class
- Adds useHostNetwork to BuildParameters class
- Passes useHostNetwork parameter to docker command to add `--net=host`
- Updates unity versions in workflow test for testing builds, so macos-latest can build them 

This allows access, for example, to licensing servers that are inside a VPN, when VPN access is configured inside the Github Action

#### Test Builds in home repo

- https://github.com/lupidan/unity-builder/actions/runs/24581311490
- https://github.com/lupidan/unity-builder/actions/runs/24581311507
- https://github.com/lupidan/unity-builder/actions/runs/24581311508

#### Checklist

- [x] Read the contribution [guide](https://github.com/game-ci/unity-builder/blob/main/CONTRIBUTING.md) and accept the [code](https://github.com/game-ci/unity-builder/blob/main/CODE_OF_CONDUCT.md) of conduct
- [X] Docs: https://github.com/game-ci/documentation/pull/554
- [x] Readme _(not needed)_
- [X] Tests _(Added for Input and BuildParameters)_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new useHostNetwork option to enable Docker host-networking on Linux.

* **Tests**
  * Added unit tests covering the new option’s parsing and default behavior.

* **Chores**
  * Updated CI build matrices to newer Unity editor versions for macOS, Ubuntu, and Windows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->