### PR TITLE
Fix wrong mac path for License Server Activation when using Unity 6.3+

### DIFF
--- a/dist/platforms/mac/steps/activate.sh
+++ b/dist/platforms/mac/steps/activate.sh
@@ -35,7 +35,16 @@ elif [[ -n "$UNITY_LICENSING_SERVER" ]]; then
   mkdir -p "$UNITY_LICENSE_PATH/config/"
   cp "$ACTION_FOLDER/unity-config/services-config.json" "$UNITY_LICENSE_PATH/config/services-config.json"
 
-  /Applications/Unity/Hub/Editor/$UNITY_VERSION/Unity.app/Contents/Frameworks/UnityLicensingClient.app/Contents/MacOS/Unity.Licensing.Client \
+  UNITY_EDITOR_DIR="/Applications/Unity/Hub/Editor/$UNITY_VERSION/Unity.app"
+  UNITY_LICENSING_CLIENT_SUBDIR="Frameworks"
+
+  # Unity 6000.3+ moved UnityLicensingClient from Contents/Frameworks to Contents/Helpers.
+  # See: https://docs.unity.com/en-us/licensing-server/client-config
+  if [[ "$UNITY_VERSION" =~ ^6000\.([3-9]|[1-9][0-9]) ]]; then
+    UNITY_LICENSING_CLIENT_SUBDIR="Helpers"
+  fi
+
+  "$UNITY_EDITOR_DIR/Contents/$UNITY_LICENSING_CLIENT_SUBDIR/UnityLicensingClient.app/Contents/MacOS/Unity.Licensing.Client" \
     --acquire-floating > license.txt
 
   # Store the exit code from the verify command

--- a/dist/platforms/mac/steps/return_license.sh
+++ b/dist/platforms/mac/steps/return_license.sh
@@ -9,7 +9,16 @@ if [[ -n "$UNITY_LICENSING_SERVER" ]]; then
   # Return any floating license used.
   #
   echo "Returning floating license: \"$FLOATING_LICENSE\""
-  /Applications/Unity/Hub/Editor/$UNITY_VERSION/Unity.app/Contents/Frameworks/UnityLicensingClient.app/Contents/MacOS/Unity.Licensing.Client \
+  UNITY_EDITOR_DIR="/Applications/Unity/Hub/Editor/$UNITY_VERSION/Unity.app"
+  UNITY_LICENSING_CLIENT_SUBDIR="Frameworks"
+
+  # Unity 6000.3+ moved UnityLicensingClient from Contents/Frameworks to Contents/Helpers.
+  # See: https://docs.unity.com/en-us/licensing-server/client-config
+  if [[ "$UNITY_VERSION" =~ ^6000\.([3-9]|[1-9][0-9]) ]]; then
+    UNITY_LICENSING_CLIENT_SUBDIR="Helpers"
+  fi
+
+  "$UNITY_EDITOR_DIR/Contents/$UNITY_LICENSING_CLIENT_SUBDIR/UnityLicensingClient.app/Contents/MacOS/Unity.Licensing.Client" \
     --return-floating "$FLOATING_LICENSE"
 elif [[ -n "$UNITY_SERIAL" ]]; then
   #

--- a/src/integrity.test.ts
+++ b/src/integrity.test.ts
@@ -1,6 +1,108 @@
 import { describe, it, expect, vi, beforeEach, afterEach, beforeAll, afterAll, test } from 'vitest';
-import { stat } from 'node:fs/promises';
-import { readFile } from 'node:fs/promises';
+import { stat, mkdtemp, mkdir, writeFile, chmod, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+type ScriptKind = 'activate' | 'return';
+
+async function makeExecutableFile(path: string, content: string): Promise<void> {
+  await writeFile(path, content, 'utf8');
+  await chmod(path, 0o755);
+}
+
+async function prepareMockUnityClient(editorDir: string): Promise<void> {
+  const frameworkClientDir = join(
+    editorDir,
+    'Contents',
+    'Frameworks',
+    'UnityLicensingClient.app',
+    'Contents',
+    'MacOS',
+  );
+  const helperClientDir = join(
+    editorDir,
+    'Contents',
+    'Helpers',
+    'UnityLicensingClient.app',
+    'Contents',
+    'MacOS',
+  );
+
+  await mkdir(frameworkClientDir, { recursive: true });
+  await mkdir(helperClientDir, { recursive: true });
+
+  const mockClient = `#!/usr/bin/env bash
+echo "$0" > "$CAPTURE_PATH_FILE"
+if [[ "$1" == "--acquire-floating" ]]; then
+  echo '"ok"'
+  echo '"floating-license"'
+  echo '"timeout"'
+  echo '"3600"'
+fi
+`;
+
+  await makeExecutableFile(join(frameworkClientDir, 'Unity.Licensing.Client'), mockClient);
+  await makeExecutableFile(join(helperClientDir, 'Unity.Licensing.Client'), mockClient);
+}
+
+async function executeAndCaptureResolvedClientPath(
+  sourceScriptPath: string,
+  unityVersion: string,
+  kind: ScriptKind,
+): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'unity-builder-integrity-'));
+  const editorDir = join(root, 'mock-editor', 'Unity.app');
+  const activatePath = join(root, 'activate-path');
+  const unityLicensePath = join(root, 'unity-license-path');
+  const actionFolder = join(root, 'action-folder');
+  const unityConfigDir = join(actionFolder, 'unity-config');
+  const capturePathFile = join(root, 'captured-client-path.txt');
+  const localScriptPath = join(root, kind === 'activate' ? 'activate.sh' : 'return_license.sh');
+
+  await mkdir(activatePath, { recursive: true });
+  await mkdir(unityLicensePath, { recursive: true });
+  await mkdir(unityConfigDir, { recursive: true });
+  await writeFile(join(unityConfigDir, 'services-config.json'), '{}', 'utf8');
+  await prepareMockUnityClient(editorDir);
+
+  const scriptSource = await readFile(sourceScriptPath, 'utf8');
+  const patchedScript = scriptSource.replace(
+    'UNITY_EDITOR_DIR="/Applications/Unity/Hub/Editor/$UNITY_VERSION/Unity.app"',
+    'UNITY_EDITOR_DIR="$TEST_UNITY_EDITOR_DIR"',
+  );
+  await makeExecutableFile(localScriptPath, patchedScript);
+
+  const environment: NodeJS.ProcessEnv = {
+    ...process.env,
+    TEST_UNITY_EDITOR_DIR: editorDir,
+    ACTIVATE_LICENSE_PATH: activatePath,
+    UNITY_LICENSE_PATH: unityLicensePath,
+    ACTION_FOLDER: actionFolder,
+    UNITY_LICENSING_SERVER: 'http://mock-server',
+    UNITY_VERSION: unityVersion,
+    CAPTURE_PATH_FILE: capturePathFile,
+    UNITY_SERIAL: '',
+    UNITY_EMAIL: '',
+    UNITY_PASSWORD: '',
+    FLOATING_LICENSE: 'floating-license',
+  };
+
+  await execFileAsync('bash', [localScriptPath], { env: environment });
+
+  return (await readFile(capturePathFile, 'utf8')).trim();
+}
+
+async function expectVersionGateBehavior(scriptPath: string, kind: ScriptKind): Promise<void> {
+  const belowGatePath = await executeAndCaptureResolvedClientPath(scriptPath, '6000.2.9f1', kind);
+  const aboveGatePath = await executeAndCaptureResolvedClientPath(scriptPath, '6000.3.0f1', kind);
+
+  expect(belowGatePath).toContain('/Contents/Frameworks/UnityLicensingClient.app/Contents/MacOS/Unity.Licensing.Client');
+  expect(aboveGatePath).toContain('/Contents/Helpers/UnityLicensingClient.app/Contents/MacOS/Unity.Licensing.Client');
+}
 
 describe('Integrity tests', () => {
   describe('package-lock.json', () => {
@@ -14,26 +116,16 @@ describe('Integrity tests', () => {
       const activateScriptPath = `${process.cwd()}/dist/platforms/mac/steps/activate.sh`;
       const activateScript = await readFile(activateScriptPath, 'utf8');
 
-      expect(activateScript).toContain('UNITY_LICENSING_CLIENT_SUBDIR="Frameworks"');
-      expect(activateScript).toContain('UNITY_LICENSING_CLIENT_SUBDIR="Helpers"');
-      expect(activateScript).toContain('^6000\\.([3-9]|[1-9][0-9])');
       expect(activateScript).toContain('https://docs.unity.com/en-us/licensing-server/client-config');
-      expect(activateScript).toContain(
-        '"$UNITY_EDITOR_DIR/Contents/$UNITY_LICENSING_CLIENT_SUBDIR/UnityLicensingClient.app/Contents/MacOS/Unity.Licensing.Client"',
-      );
+      await expectVersionGateBehavior(activateScriptPath, 'activate');
     });
 
     it('return license script uses the same Unity version-gated path logic', async () => {
       const returnLicenseScriptPath = `${process.cwd()}/dist/platforms/mac/steps/return_license.sh`;
       const returnLicenseScript = await readFile(returnLicenseScriptPath, 'utf8');
 
-      expect(returnLicenseScript).toContain('UNITY_LICENSING_CLIENT_SUBDIR="Frameworks"');
-      expect(returnLicenseScript).toContain('UNITY_LICENSING_CLIENT_SUBDIR="Helpers"');
-      expect(returnLicenseScript).toContain('^6000\\.([3-9]|[1-9][0-9])');
       expect(returnLicenseScript).toContain('https://docs.unity.com/en-us/licensing-server/client-config');
-      expect(returnLicenseScript).toContain(
-        '"$UNITY_EDITOR_DIR/Contents/$UNITY_LICENSING_CLIENT_SUBDIR/UnityLicensingClient.app/Contents/MacOS/Unity.Licensing.Client"',
-      );
+      await expectVersionGateBehavior(returnLicenseScriptPath, 'return');
     });
   });
 });

--- a/src/integrity.test.ts
+++ b/src/integrity.test.ts
@@ -1,10 +1,39 @@
 import { describe, it, expect, vi, beforeEach, afterEach, beforeAll, afterAll, test } from 'vitest';
 import { stat } from 'node:fs/promises';
+import { readFile } from 'node:fs/promises';
 
 describe('Integrity tests', () => {
   describe('package-lock.json', () => {
     it('does not exist', async () => {
       await expect(stat(`${process.cwd()}/package-lock.json`)).rejects.toThrowError();
+    });
+  });
+
+  describe('mac licensing scripts', () => {
+    it('activate script switches Unity Licensing Client path for Unity 6000.3+', async () => {
+      const activateScriptPath = `${process.cwd()}/dist/platforms/mac/steps/activate.sh`;
+      const activateScript = await readFile(activateScriptPath, 'utf8');
+
+      expect(activateScript).toContain('UNITY_LICENSING_CLIENT_SUBDIR="Frameworks"');
+      expect(activateScript).toContain('UNITY_LICENSING_CLIENT_SUBDIR="Helpers"');
+      expect(activateScript).toContain('^6000\\.([3-9]|[1-9][0-9])');
+      expect(activateScript).toContain('https://docs.unity.com/en-us/licensing-server/client-config');
+      expect(activateScript).toContain(
+        '"$UNITY_EDITOR_DIR/Contents/$UNITY_LICENSING_CLIENT_SUBDIR/UnityLicensingClient.app/Contents/MacOS/Unity.Licensing.Client"',
+      );
+    });
+
+    it('return license script uses the same Unity version-gated path logic', async () => {
+      const returnLicenseScriptPath = `${process.cwd()}/dist/platforms/mac/steps/return_license.sh`;
+      const returnLicenseScript = await readFile(returnLicenseScriptPath, 'utf8');
+
+      expect(returnLicenseScript).toContain('UNITY_LICENSING_CLIENT_SUBDIR="Frameworks"');
+      expect(returnLicenseScript).toContain('UNITY_LICENSING_CLIENT_SUBDIR="Helpers"');
+      expect(returnLicenseScript).toContain('^6000\\.([3-9]|[1-9][0-9])');
+      expect(returnLicenseScript).toContain('https://docs.unity.com/en-us/licensing-server/client-config');
+      expect(returnLicenseScript).toContain(
+        '"$UNITY_EDITOR_DIR/Contents/$UNITY_LICENSING_CLIENT_SUBDIR/UnityLicensingClient.app/Contents/MacOS/Unity.Licensing.Client"',
+      );
     });
   });
 });


### PR DESCRIPTION
#### Changes

- As per the [Unity docs](https://docs.unity.com/en-us/licensing-server/client-config), the path for the Licensing Client on macOS changed for Editor versions 6000.3 or later:
```
macOS (Editor versions 6000.3 or later):
<UnityEditorDir>/Contents/Helpers/UnityLicensingClient.app/Contents/MacOS/

macOS (Editor versions 2021.3.19f1 through 6000.2):
<UnityEditorDir>/Contents/Frameworks/UnityLicensingClient.app/Contents/MacOS/
```

The paths for activation in the activate and return_license scripts were hardcoded to:
```
/Applications/Unity/Hub/Editor/$UNITY_VERSION/Unity.app/Contents/Frameworks/UnityLicensingClient.app/Contents/MacOS/Unity.Licensing.Client \
````
But for Unity 6.3+, the **/Frameworks/** substring changed to **/Helpers/** instead. This PR detects the Unity version and then changes the Licensing Client path depending on that.
* ➡️ **Impact:** Fixes the use of Licensing Servers with `game-ci/unity-builder` on Unity Editor versions of 6.3+ on macs (e.g. used for iOS builds)

#### Related Issues

- N/A

#### Related PRs

- N/A

#### Successful Workflow Run Link

PRs don't have access to secrets so you will need to provide a link to a successful run of the workflows from your own
repo.

- Can't share the private repo results but I'll screenshot the relevant pieces that have no sensitive info

##### BEFORE
```
Run game-ci/unity-builder@v4
  with:
    targetPlatform: iOS
    buildName: iOS-Device
    buildsPath: Build
    versioning: None
    unityVersion: 6000.3.5f2
    androidExportType: androidPackage
    androidSymbolType: none
    runAsHostUser: false
    dockerIsolationMode: default
    containerRegistryRepository: unityci/editor
    containerRegistryImageVersion: 3
    awsStackName: game-ci
    providerStrategy: local
    kubeVolumeSize: 5Gi
    watchToEnd: true
    cacheUnityInstallationOnMac: false
    dockerWorkspacePath: /github/workspace
    skipActivation: false
  env:
    UNITY_LICENSE_SERVER_URL: ***
    UNITY_VERSION: 6000.3.5f2
    UNITY_VERSION_CHANGESET: 3fa8bc678cb0
    BUILD_VERSION: 0.9.0-rc.495
    UNITY_LICENSING_SERVER: ***
    UNITY_CI: true
```
🔴 Error when trying to build with `game-ci/unity-builder` on Unity 6.3, build target iOS

```
/bin/bash /Users/runner/work/_actions/game-ci/unity-builder/v4/dist/platforms/mac/entrypoint.sh
Creating Unity License Directory
Changing to "/Users/runner/work/_actions/game-ci/unity-builder/v4/dist/BlankProject" directory.
~/work/_actions/game-ci/unity-builder/v4/dist/BlankProject ~/work/vrify-unity/vrify-unity
Adding licensing server config
/Users/runner/work/_actions/game-ci/unity-builder/v4/dist/platforms/mac/steps/activate.sh: line 39: /Applications/Unity/Hub/Editor/6000.3.5f2/Unity.app/Contents/Frameworks/UnityLicensingClient.app/Contents/MacOS/Unity.Licensing.Client: No such file or directory
Unclassified error occured while trying to activate license.
Exit code was: 127
Error: There was an error while trying to activate the Unity license.
Error: Build failed with exit code 127
```

#### AFTER
Floating license was properly acquired

<img width="1007" height="599" alt="acquired floating license" src="https://github.com/user-attachments/assets/61dda672-5f9c-409f-a5b3-0a7592798f6b" />

License properly returned

<img width="1011" height="512" alt="return floating license" src="https://github.com/user-attachments/assets/74957e8e-6236-4684-abae-bd1e5162cfd9" />


#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](https://github.com/game-ci/unity-builder/blob/main/CONTRIBUTING.md) and accept the
      [code](https://github.com/game-ci/unity-builder/blob/main/CODE_OF_CONDUCT.md) of conduct
- [ ] Docs (If new inputs or outputs have been added or changes to behavior that should be documented. Please make a PR
      in the [documentation repo](https://github.com/game-ci/documentation))
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded build integrity checks to cover the built macOS Unity licensing scripts.
  * Added verification that the generated scripts include the expected documentation link.
  * Added coverage for version-gated behavior to ensure the correct Unity licensing app path is resolved for both below and at/above the gate.
  * Continued validation that `package-lock.json` is not present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->