### PR TITLE
fix: sync-secrets wrote "-" as the value of every secret it synced

### DIFF
--- a/.github/workflows/sync-secrets.yml
+++ b/.github/workflows/sync-secrets.yml
@@ -70,7 +70,14 @@ jobs:
             if [ "$DRY_RUN" = "true" ]; then
               echo "🔍 DRY RUN: would sync $name → $TARGET_REPO"
             else
-              if echo "$value" | gh secret set "$name" -R "$TARGET_REPO" --body - 2>/dev/null; then
+              # `gh secret set` reads the value from stdin only when --body is
+              # NOT passed. `--body -` does not mean "read stdin" - gh takes it
+              # literally, so this wrote the single character "-" as the value
+              # of every secret it synced, silently destroying them. (A secret
+              # whose value is "-" also makes Actions mask every hyphen in the
+              # logs, which mangles unrelated output like image tags:
+              # "unityci/editor:ubuntu***2022.3.7f1***linux***il2cpp***3".)
+              if gh secret set "$name" -R "$TARGET_REPO" --body "$value" 2>/dev/null; then
                 echo "✅ SYNCED: $name → $TARGET_REPO"
               else
                 echo "⚠️ FAILED: $name → $TARGET_REPO (continuing)"


### PR DESCRIPTION
## The bug

`gh secret set` reads the value from stdin **only when `--body` is not passed**:

> `-b, --body string   The value for the secret (reads from standard input if not specified)`

`--body -` does *not* mean "read stdin" — gh takes it literally. So this line:

```bash
echo "$value" | gh secret set "$name" -R "$TARGET_REPO" --body -
```

piped the real value into a process that ignored stdin, and stored the single character `-` as the secret's value. It still exits 0, so the workflow cheerfully reported `✅ SYNCED` for every secret while destroying all of them.

## How it surfaced

I hit this making the exact same mistake by hand while fixing Unity licensing for [unity-test-runner#310](https://github.com/game-ci/unity-test-runner/pull/310). Two symptoms:

1. Activation failed immediately with `Unclassified error occured while trying to activate license. Exit code was: 1`.
2. Actions masks a secret's value wherever it appears in logs — and with the value set to `-`, **every hyphen in unrelated output** became `***`:

```
Unable to find image 'unityci/editor:ubuntu***2022.3.7f1***linux***il2cpp***3'
```

That mangled image tag is what made the cause obvious.

## Why this matters beyond the workflow

This is a plausible explanation for the **stale/broken org-level Unity secrets** we've been working around: any past run of this workflow would have overwritten its targets with `-`. Worth checking `game-ci/orchestrator` and `game-ci/cli` (the only two `target_repo` options) for secrets that look "set" but are actually `-`.

Symptom to look for: hyphens showing up as `***` in that repo's Actions logs.

## The fix

Passes the value via `--body` directly. Behaviour is otherwise unchanged — including the dry-run path, which never called `gh` at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved secret synchronization reliability by ensuring secret values are passed correctly during setup.
  * Added documentation clarifying the synchronization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->