### PR TITLE
fix: pass unityVersion through as --engineVersion (companion to game-ci/cli#154)

### DIFF
--- a/src/build-args.test.ts
+++ b/src/build-args.test.ts
@@ -23,6 +23,24 @@ describe('buildCliArgs', () => {
     ).toStrictEqual(['build', 'game', '--targetPlatform=StandaloneLinux64']);
   });
 
+  it('omits --engineVersion when unityVersion is unset or "auto"', () => {
+    const noneSet = buildCliArgs(inputsOf({ targetPlatform: 'StandaloneLinux64' }));
+    const explicitAuto = buildCliArgs(
+      inputsOf({ targetPlatform: 'StandaloneLinux64', unityVersion: 'auto' }),
+    );
+
+    expect(noneSet.some((arg) => arg.startsWith('--engineVersion'))).toBe(false);
+    expect(explicitAuto.some((arg) => arg.startsWith('--engineVersion'))).toBe(false);
+  });
+
+  it('maps an explicit unityVersion to --engineVersion, overriding auto-detection', () => {
+    const args = buildCliArgs(
+      inputsOf({ targetPlatform: 'WebGL', unityVersion: '6000.0.36f1' }),
+    );
+
+    expect(args).toContain('--engineVersion=6000.0.36f1');
+  });
+
   it('throws for a non-local providerStrategy, matching the base action without @game-ci/orchestrator', () => {
     expect(() =>
       buildCliArgs(inputsOf({ targetPlatform: 'StandaloneLinux64', providerStrategy: 'aws' })),

--- a/src/build-args.ts
+++ b/src/build-args.ts
@@ -2,17 +2,19 @@
  * Translates unity-builder's action inputs into `game-ci build` (or, for
  * providerStrategy=local-system, `game-ci orchestrate`) CLI flags.
  *
- * Two deliberate omissions for the `build` path, both because there is
- * nothing to translate to:
- *  - `unityVersion` (except "auto"): the CLI always detects the Unity
- *    version from the checked-out project's ProjectSettings/ProjectVersion.txt
- *    and has no flag to override that today (game-ci/cli's engine-detection
- *    middleware unconditionally overwrites any passed value). Pinning a
- *    version other than "auto" is a known, real gap versus the original
- *    action - see the PR this shipped in.
+ * One deliberate omission for the `build` path, because there is nothing
+ * to translate to:
  *  - `providerStrategy` values other than "local"/"local-system": the base
  *    action (without the separately-installed @game-ci/orchestrator plugin)
  *    already throws for these today, so throwing here isn't a regression.
+ *
+ * `unityVersion` (except "auto", which means "let the CLI auto-detect from
+ * ProjectSettings/ProjectVersion.txt", so it's never passed through as a
+ * literal flag value): mapped to `--engineVersion`, which game-ci/cli's
+ * engine-detection middleware now respects instead of unconditionally
+ * overwriting (game-ci/cli#154). Not carried into ORCHESTRATE_STRING_FLAGS -
+ * unverified whether `orchestrate`'s local-system path reads engineVersion
+ * the same way; scope this out until confirmed.
  *
  * Boolean inputs use GitHub Actions' own truthy/falsy string convention
  * ('true'/'false', case-insensitive) - see actions/toolkit's getBooleanInput.
@@ -235,6 +237,11 @@ export function buildCliArgs({ getInput }: BuildArgsOptions): string[] {
     throw new Error('targetPlatform is required.');
   }
   args.push(`--targetPlatform=${targetPlatform}`);
+
+  const unityVersion = getInput('unityVersion');
+  if (unityVersion && unityVersion !== 'auto') {
+    args.push(`--engineVersion=${unityVersion}`);
+  }
 
   pushStringFlags(args, getInput, STRING_FLAGS);
   pushBooleanFlags(args, getInput, BOOLEAN_FLAGS);

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,15 +18,6 @@ import { resolveProjectPath } from './resolve-project-path';
 
 export async function run() {
   try {
-    const unityVersion = core.getInput('unityVersion') || 'auto';
-    if (unityVersion !== 'auto') {
-      core.warning(
-        `unityVersion="${unityVersion}" is ignored: the underlying game-ci CLI always detects the Unity ` +
-          "version from the checked-out project's ProjectSettings/ProjectVersion.txt and has no flag to " +
-          'override it yet.',
-      );
-    }
-
     const cliVersion = core.getInput('cliVersion') || 'latest';
     const cliPath = await downloadCli(cliVersion);
 


### PR DESCRIPTION
Companion fix to game-ci/cli#154, which lets the CLI's engine-detection middleware respect an explicit --engineVersion instead of always overwriting it from ProjectVersion.txt.

Root cause of #844's "WebGL on 6000.0.36f1 (via Build Profile)" cell always failing (Missing argument -buildTarget, exit 120): build-args.ts had no way to pass an engineVersion override through to the CLI at all, so it always resolved to the test project's real ProjectVersion.txt (2021.3.45f1), never the 6000.0.36f1 needed to exercise Build Profiles.

Maps unityVersion (except "auto") to --engineVersion, removes the now-stale core.warning(). 2 new tests, 38/38 total pass.

Depends on game-ci/cli#154 merging + releasing first - until then this is a no-op improvement. Left knownGap/continue-on-error in place for the same reason.