### PR TITLE
ci: add unity-test-runner/unity-activate as sync-secrets.yml targets

### DIFF
--- a/.github/workflows/sync-secrets.yml
+++ b/.github/workflows/sync-secrets.yml
@@ -11,6 +11,8 @@ on:
         options:
           - game-ci/orchestrator
           - game-ci/cli
+          - game-ci/unity-test-runner
+          - game-ci/unity-activate
       dry_run:
         description: 'Dry run (list secrets to sync without writing)'
         required: false


### PR DESCRIPTION
## Summary
unity-test-runner's own repo secrets only ever had \`UNITY_LICENSE\` configured, never the working \`UNITY_SERIAL\`/\`EMAIL\`/\`PASSWORD\` unity-builder itself uses successfully on Windows. This workflow already had the capability to sync secrets to another repo, but \`unity-test-runner\` was never a valid \`target_repo\` option - so it was simply never run for it.

Confirmed via unity-test-runner's own CI: Windows activation was failing on a genuine Unity machine-binding constraint specific to the personal-license \`.ulf\` file (see [game-ci/cli#204](https://github.com/game-ci/cli/pull/204)'s investigation) - a real \`UNITY_SERIAL\` doesn't have that constraint, and is what already works reliably for unity-builder's own Windows CI.

\`unity-activate\` added as a target too, for the same reason - another thin-wrapper repo in the same position.

## Test plan
- [x] YAML is valid (just adds two more `choice` options)
- [ ] Once merged, dispatch this workflow targeting `game-ci/unity-test-runner` to actually perform the sync

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `game-ci/unity-test-runner` and `game-ci/unity-activate` as selectable repository options in the secrets synchronization workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->